### PR TITLE
Fix suggestions

### DIFF
--- a/src/Template/Admin/TranslateStrings/translate.ctp
+++ b/src/Template/Admin/TranslateStrings/translate.ctp
@@ -63,7 +63,7 @@
 			$key = $translateLanguage['iso2'];
 			echo $this->Form->input('content_'.$key, ['type'=>'textarea','label'=>h($translateLanguage['name']), 'rel'=>$key]);
 			if (!empty($suggestions[$key])) {
-				echo $this->element('suggestions', ['suggestions' => $suggestions[$key], 'target' => 'content-' . $key]);
+				echo $this->element('suggestions', ['suggestions' => $suggestions[$key], 'key' => $key]);
 			}
 		}
 	}

--- a/src/Template/Element/suggestions.ctp
+++ b/src/Template/Element/suggestions.ctp
@@ -13,13 +13,15 @@ foreach ($suggestions as $engine => $suggestion) {
 	$suggestionsArray[$suggestion][] = substr($engine, strrpos($engine, '\\') + 1);
 }
 
+$target = 'content-' .$key;
+
 ?>
 <div class="form-group suggestions">
 	<label class="control-label col-md-4 col-lg-3"><small><?php echo __('Suggestions'); ?></small></label>
 	<div class="col-md-8 col-lg-9">
 		<ul>
 	<?php foreach ($suggestionsArray as $suggestion => $engines) { ?>
-		<li><span class="suggest" title="Click to insert"><?php echo h($suggestion); ?></span> <small>(<?php echo implode(', ', $engines); ?>)</small></li>
+		<li><span class="suggest" rel="<?php echo $key; ?>" title="Click to insert"><?php echo h($suggestion); ?></span> <small>(<?php echo implode(', ', $engines); ?>)</small></li>
 	<?php } ?>
 		</ul>
 	</div>
@@ -35,9 +37,9 @@ foreach ($suggestions as $engine => $suggestion) {
 <?php $this->append('script'); ?>
 <script>
 	$(function() {
-		$('.suggestions .suggest').click(function() {
-			var value = $(this).text();
+		$('.suggest[rel="<?php echo $key; ?>"]').click(function() {
 			var input = $('#<?php echo $target; ?>');
+			var value = $(this).text();
 			input.val(value);
 			return false;
 		});


### PR DESCRIPTION
If one has more than one language and presses any of the suggestions of any language all translation fields will be populated with the clicked suggestion, intead of just the language related translation field.

This change fixes this.