### PR TITLE
Remove prefix from link

### DIFF
--- a/templates/Admin/Translate/index.php
+++ b/templates/Admin/Translate/index.php
@@ -67,7 +67,7 @@ Current Translation-Coverage: <span style="color:#<?php echo $totalColor;?>;font
 <?php } else { ?>
 
 	<p>
-<?php echo __d('translate', 'Please create a project first'); ?>: <?php echo $this->Html->link('Project Index', ['prefix' => 'admin', 'controller' => 'TranslateProjects']); ?>
+<?php echo __d('translate', 'Please create a project first'); ?>: <?php echo $this->Html->link('Project Index', ['controller' => 'TranslateProjects']); ?>
 	</p>
 
 <?php } ?>


### PR DESCRIPTION
Prefix caused a router configuration error. Removing the prefix causes the page to function correctly.