### PR TITLE
Fix DbMessagesLoader class name in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,8 +88,10 @@ bin/cake i18n extract_to_db
 Configure I18n to use the Translate DbMessagesLoader for default domain:
 
 ```php
+use Translate\I18n\DbMessagesLoader;
+
 I18n::config('default', function ($domain, $locale) {
-    return new MessagesDbLoader(
+    return new DbMessagesLoader(
         $domain,
         $locale
     );


### PR DESCRIPTION
## Summary
- Fixed incorrect class name `MessagesDbLoader` to `DbMessagesLoader` in the documentation
- Added the `use` statement for clarity

The actual class is `Translate\I18n\DbMessagesLoader`, not `MessagesDbLoader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)