### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/I18nEntries/edit.php
+++ b/templates/Admin/I18nEntries/edit.php
@@ -12,6 +12,7 @@
  * @var array<array<string, string>> $glossarySuggestions
  * @var string $foreignKeyColumn
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
@@ -209,7 +210,7 @@
 	</div>
 </div>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	// Copy suggestion to clipboard
 	document.querySelectorAll('.copy-suggestion').forEach(function(btn) {

--- a/templates/Admin/I18nEntries/entries.php
+++ b/templates/Admin/I18nEntries/entries.php
@@ -13,6 +13,7 @@
 
 $this->Html->script('https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js', ['block' => true]);
 $this->Html->css('https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css', ['block' => true]);
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
@@ -235,15 +236,17 @@ $this->Html->css('https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/c
 											['action' => 'edit', $tableName, $entry->id],
 											['class' => 'btn btn-sm btn-outline-secondary', 'escape' => false, 'title' => __d('translate', 'Edit')],
 										) ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											'<i class="fas fa-trash"></i>',
 											['action' => 'delete', $tableName, $entry->id],
 											[
 												'class' => 'btn btn-sm btn-outline-danger',
 												'escape' => false,
 												'title' => __d('translate', 'Delete'),
-												'confirm' => __d('translate', 'Are you sure you want to delete this entry?'),
-												'block' => true,
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete this entry?'),
+												],
 											],
 										) ?>
 									</td>
@@ -261,7 +264,7 @@ $this->Html->css('https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/c
 </div>
 <?= $this->Form->end() ?>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	const checkAll = document.getElementById('check-all');
 	const selectAll = document.getElementById('select-all');

--- a/templates/Admin/I18nEntries/entries_base.php
+++ b/templates/Admin/I18nEntries/entries_base.php
@@ -13,6 +13,7 @@
  * @var string $foreignKeyColumn
  * @var string|null $displayField
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
@@ -96,7 +97,7 @@
 							<?php } ?>
 						</select>
 					</div>
-					<button type="submit" class="btn btn-info btn-sm" onclick="return confirmBatch()">
+					<button type="submit" class="btn btn-info btn-sm" data-action="confirm-batch">
 						<i class="fas fa-magic"></i> <?= __d('translate', 'Auto-translate Selected') ?>
 					</button>
 				</div>
@@ -227,7 +228,7 @@
 	</div>
 </div>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	const selectAll = document.getElementById('select-all');
 	const checkboxes = document.querySelectorAll('.record-checkbox');
@@ -239,6 +240,15 @@ document.addEventListener('DOMContentLoaded', function() {
 	checkboxes.forEach(cb => {
 		cb.addEventListener('change', function() {
 			selectAll.checked = [...checkboxes].every(c => c.checked);
+		});
+	});
+
+	// CSP-safe replacement for <button onclick="return confirmBatch()">
+	document.querySelectorAll('[data-action="confirm-batch"]').forEach(function(btn) {
+		btn.addEventListener('click', function(e) {
+			if (!confirmBatch()) {
+				e.preventDefault();
+			}
 		});
 	});
 });

--- a/templates/Admin/I18nEntries/index.php
+++ b/templates/Admin/I18nEntries/index.php
@@ -126,14 +126,17 @@
 							['class' => 'btn btn-primary btn-sm', 'escape' => false],
 						) ?>
 						<?php if ($info['base_exists'] && $info['row_count'] < $info['base_count']) { ?>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-sync"></i> ' . __d('translate', 'Sync'),
 								['action' => 'sync', $tableName],
 								[
 									'class' => 'btn btn-warning btn-sm',
 									'escape' => false,
 									'title' => __d('translate', 'Create missing translation entries'),
-									'confirm' => __d('translate', 'Create empty translation entries for {0} missing records?', $info['base_count'] - $info['row_count']),
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('translate', 'Create empty translation entries for {0} missing records?', $info['base_count'] - $info['row_count']),
+									],
 								],
 							) ?>
 						<?php } ?>

--- a/templates/Admin/I18nEntries/view.php
+++ b/templates/Admin/I18nEntries/view.php
@@ -168,7 +168,7 @@
 			<div class="card-body">
 				<div class="d-grid gap-2">
 					<?php if ($hasAutoField) { ?>
-						<?= $this->Form->postLink(
+						<?= $this->Form->postButton(
 							$entry->auto
 								? '<i class="fas fa-user"></i> ' . __d('translate', 'Mark as Manual')
 								: '<i class="fas fa-robot"></i> ' . __d('translate', 'Mark as Auto'),
@@ -176,18 +176,22 @@
 							[
 								'class' => 'btn btn-outline-' . ($entry->auto ? 'warning' : 'info'),
 								'escape' => false,
-								'block' => true,
+								'form' => [
+									'class' => 'd-grid',
+								],
 							],
 						) ?>
 					<?php } ?>
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 						['action' => 'delete', $tableName, $entry->id],
 						[
 							'class' => 'btn btn-outline-danger',
 							'escape' => false,
-							'confirm' => __d('translate', 'Are you sure you want to delete this entry?'),
-							'block' => true,
+							'form' => [
+								'class' => 'd-grid',
+								'data-confirm-message' => __d('translate', 'Are you sure you want to delete this entry?'),
+							],
 						],
 					) ?>
 				</div>

--- a/templates/Admin/I18nEntries/view_record.php
+++ b/templates/Admin/I18nEntries/view_record.php
@@ -70,13 +70,16 @@
 				<h5 class="mb-0">
 					<i class="fas fa-language"></i> <?= __d('translate', 'Translations') ?>
 				</h5>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-magic"></i> ' . __d('translate', 'Auto-translate All'),
 					['action' => 'autoTranslateRecord', $tableName, $baseRecord->id],
 					[
 						'class' => 'btn btn-info btn-sm',
 						'escape' => false,
-						'confirm' => __d('translate', 'Auto-translate this record to all configured locales?'),
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Auto-translate this record to all configured locales?'),
+						],
 					],
 				) ?>
 			</div>
@@ -174,15 +177,17 @@
 										) ?>
 									<?php } ?>
 									<?php if (!$isFullyTranslated) { ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											'<i class="fas fa-magic"></i>',
 											['action' => 'autoTranslateRecord', $tableName, $baseRecord->id, '?' => ['locales' => [$locale]]],
 											[
 												'class' => 'btn btn-sm btn-outline-info',
 												'escape' => false,
 												'title' => __d('translate', 'Auto-translate'),
-												'confirm' => __d('translate', 'Auto-translate to {0}?', $locale),
-												'block' => true,
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Auto-translate to {0}?', $locale),
+												],
 											],
 										) ?>
 									<?php } ?>

--- a/templates/Admin/Translate/index.php
+++ b/templates/Admin/Translate/index.php
@@ -156,7 +156,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<div class="progress" style="height: 20px;">
 									<div class="progress-bar <?= $stats['percentage'] >= 80 ? 'bg-success' : ($stats['percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 										role="progressbar"
-										style="width: <?= $stats['percentage'] ?>%"
+										data-progress-width="<?= $stats['percentage'] ?>"
 										aria-valuenow="<?= $stats['percentage'] ?>"
 										aria-valuemin="0"
 										aria-valuemax="100">

--- a/templates/Admin/Translate/reset.php
+++ b/templates/Admin/Translate/reset.php
@@ -49,10 +49,17 @@
 				</p>
 
 				<div class="btn-group">
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-exclamation-triangle"></i> ' . __d('translate', 'Hard reset Translate (fully truncate all tables)'),
 						['?' => ['hard-reset' => '1']],
-						['confirm' => __d('translate', 'Sure?'), 'class' => 'btn btn-danger', 'escapeTitle' => false]
+						[
+							'class' => 'btn btn-danger',
+							'escapeTitle' => false,
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('translate', 'Sure?'),
+							],
+						]
 					) ?>
 				</div>
 			</div>

--- a/templates/Admin/Translate/stats.php
+++ b/templates/Admin/Translate/stats.php
@@ -34,7 +34,7 @@
 					<div class="progress mt-1" style="height: 25px;">
 						<div class="progress-bar <?= $grandTotal['translation_percentage'] >= 80 ? 'bg-success' : ($grandTotal['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 							role="progressbar"
-							style="width: <?= $grandTotal['translation_percentage'] ?>%"
+							data-progress-width="<?= $grandTotal['translation_percentage'] ?>"
 							aria-valuenow="<?= $grandTotal['translation_percentage'] ?>"
 							aria-valuemin="0"
 							aria-valuemax="100">
@@ -51,7 +51,7 @@
 					<div class="progress mt-1" style="height: 25px;">
 						<div class="progress-bar bg-info"
 							role="progressbar"
-							style="width: <?= $grandTotal['confirmation_percentage'] ?>%"
+							data-progress-width="<?= $grandTotal['confirmation_percentage'] ?>"
 							aria-valuenow="<?= $grandTotal['confirmation_percentage'] ?>"
 							aria-valuemin="0"
 							aria-valuemax="100">
@@ -110,7 +110,7 @@
 									<div class="progress" style="height: 20px;">
 										<div class="progress-bar <?= $data['translation_percentage'] >= 80 ? 'bg-success' : ($data['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 											role="progressbar"
-											style="width: <?= $data['translation_percentage'] ?>%"
+											data-progress-width="<?= $data['translation_percentage'] ?>"
 											aria-valuenow="<?= $data['translation_percentage'] ?>"
 											aria-valuemin="0"
 											aria-valuemax="100">
@@ -132,7 +132,7 @@
 									<div class="progress" style="height: 20px;">
 										<div class="progress-bar bg-info"
 											role="progressbar"
-											style="width: <?= $data['confirmation_percentage'] ?>%"
+											data-progress-width="<?= $data['confirmation_percentage'] ?>"
 											aria-valuenow="<?= $data['confirmation_percentage'] ?>"
 											aria-valuemin="0"
 											aria-valuemax="100">
@@ -195,7 +195,7 @@
 									<div class="progress" style="height: 18px;">
 										<div class="progress-bar <?= $stat['translation_percentage'] >= 80 ? 'bg-success' : ($stat['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 											role="progressbar"
-											style="width: <?= $stat['translation_percentage'] ?>%"
+											data-progress-width="<?= $stat['translation_percentage'] ?>"
 											aria-valuenow="<?= $stat['translation_percentage'] ?>"
 											aria-valuemin="0"
 											aria-valuemax="100">
@@ -217,7 +217,7 @@
 									<div class="progress" style="height: 18px;">
 										<div class="progress-bar bg-info"
 											role="progressbar"
-											style="width: <?= $stat['confirmation_percentage'] ?>%"
+											data-progress-width="<?= $stat['confirmation_percentage'] ?>"
 											aria-valuenow="<?= $stat['confirmation_percentage'] ?>"
 											aria-valuemin="0"
 											aria-valuemax="100">

--- a/templates/Admin/TranslateApiTranslations/edit.php
+++ b/templates/Admin/TranslateApiTranslations/edit.php
@@ -13,7 +13,14 @@
 			<div class="card-body p-0">
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
-						<?= $this->Form->postLink('<i class="fa fa-trash"></i> ' . __d('translate', 'Delete'), ['action' => 'delete', $translateApiTranslation->id], ['escape' => false, 'class' => 'text-danger', 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id)]) ?>
+						<?= $this->Form->postButton('<i class="fa fa-trash"></i> ' . __d('translate', 'Delete'), ['action' => 'delete', $translateApiTranslation->id], [
+							'escape' => false,
+							'class' => 'btn btn-link text-danger p-0 align-baseline',
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id),
+							],
+						]) ?>
 					</li>
 					<li class="list-group-item">
 						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escape' => false, 'class' => '']) ?>

--- a/templates/Admin/TranslateApiTranslations/index.php
+++ b/templates/Admin/TranslateApiTranslations/index.php
@@ -53,7 +53,15 @@ use Cake\Core\Plugin;
 									<div class="btn-group" role="group">
 										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateApiTranslation->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
 										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateApiTranslation->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
-										<?= $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $translateApiTranslation->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-danger', 'title' => __d('translate', 'Delete'), 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id)]) ?>
+										<?= $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $translateApiTranslation->id], [
+											'escape' => false,
+											'class' => 'btn btn-sm btn-outline-danger',
+											'title' => __d('translate', 'Delete'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id),
+											],
+										]) ?>
 									</div>
 								</td>
 							</tr>

--- a/templates/Admin/TranslateApiTranslations/view.php
+++ b/templates/Admin/TranslateApiTranslations/view.php
@@ -16,7 +16,14 @@
 						<?= $this->Html->link('<i class="fa fa-edit"></i> ' . __d('translate', 'Edit API Translation'), ['action' => 'edit', $translateApiTranslation->id], ['escape' => false, 'class' => '']) ?>
 					</li>
 					<li class="list-group-item">
-						<?= $this->Form->postLink('<i class="fa fa-trash"></i> ' . __d('translate', 'Delete API Translation'), ['action' => 'delete', $translateApiTranslation->id], ['escape' => false, 'class' => 'text-danger', 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id)]) ?>
+						<?= $this->Form->postButton('<i class="fa fa-trash"></i> ' . __d('translate', 'Delete API Translation'), ['action' => 'delete', $translateApiTranslation->id], [
+							'escape' => false,
+							'class' => 'btn btn-link text-danger p-0 align-baseline',
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateApiTranslation->id),
+							],
+						]) ?>
 					</li>
 					<li class="list-group-item">
 						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escape' => false, 'class' => '']) ?>

--- a/templates/Admin/TranslateBehavior/generate.php
+++ b/templates/Admin/TranslateBehavior/generate.php
@@ -11,6 +11,7 @@
  * @var array|null $availableTables
  * @var string $shadowTableSuffix
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <?php if (!isset($tableName)) { ?>
@@ -154,10 +155,10 @@
 							</div>
 
 							<div class="d-grid gap-2 mt-3">
-								<button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectAll()">
+								<button type="button" class="btn btn-sm btn-outline-secondary" data-action="fields-select-all">
 									<i class="fas fa-check-square"></i> <?= __d('translate', 'Select All') ?>
 								</button>
-								<button type="button" class="btn btn-sm btn-outline-secondary" onclick="deselectAll()">
+								<button type="button" class="btn btn-sm btn-outline-secondary" data-action="fields-deselect-all">
 									<i class="fas fa-square"></i> <?= __d('translate', 'Deselect All') ?>
 								</button>
 							</div>
@@ -232,7 +233,7 @@ $fieldsFormatted .= "        ]";
 						<pre class="mb-0 p-3" style="background: #2d2d2d; color: #f8f8f2; border-radius: 0; max-height: 600px; overflow-y: auto;"><code><?= h($migrationCode) ?></code></pre>
 					</div>
 					<div class="card-footer">
-						<button class="btn btn-sm btn-outline-primary" onclick="copyToClipboard()">
+						<button type="button" class="btn btn-sm btn-outline-primary" data-action="copy-migration">
 							<i class="fas fa-copy"></i> <?= __d('translate', 'Copy to Clipboard') ?>
 						</button>
 						<?= $this->Form->create(null, [
@@ -268,7 +269,7 @@ $fieldsFormatted .= "        ]";
 	</div>
 <?php } ?>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 function selectAll() {
 	document.querySelectorAll('input[name="fields[]"]').forEach(el => el.checked = true);
 }
@@ -285,4 +286,15 @@ function copyToClipboard() {
 		console.error('Failed to copy:', err);
 	});
 }
+
+// CSP-safe delegates: replace inline onclick handlers.
+document.querySelectorAll('[data-action="fields-select-all"]').forEach(function(btn) {
+	btn.addEventListener('click', selectAll);
+});
+document.querySelectorAll('[data-action="fields-deselect-all"]').forEach(function(btn) {
+	btn.addEventListener('click', deselectAll);
+});
+document.querySelectorAll('[data-action="copy-migration"]').forEach(function(btn) {
+	btn.addEventListener('click', copyToClipboard);
+});
 </script>

--- a/templates/Admin/TranslateDomains/edit.php
+++ b/templates/Admin/TranslateDomains/edit.php
@@ -12,10 +12,17 @@
 				<i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 					['action' => 'delete', $translateDomain->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),

--- a/templates/Admin/TranslateDomains/index.php
+++ b/templates/Admin/TranslateDomains/index.php
@@ -76,10 +76,18 @@ use Cake\Core\Plugin;
 											['action' => 'edit', $translateDomain->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['action' => 'delete', $translateDomain->id],
-											['escape' => false, 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id), 'class' => 'btn btn-outline-danger', 'title' => __d('translate', 'Delete')],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id),
+												],
+											],
 										) ?>
 									</div>
 								</td>

--- a/templates/Admin/TranslateDomains/view.php
+++ b/templates/Admin/TranslateDomains/view.php
@@ -17,10 +17,17 @@
 					['action' => 'edit', $translateDomain->id],
 					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Domain'),
 					['action' => 'delete', $translateDomain->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),

--- a/templates/Admin/TranslateLocales/edit.php
+++ b/templates/Admin/TranslateLocales/edit.php
@@ -12,10 +12,16 @@
 				<h3 class="card-title"><i class="fa fa-bars"></i> <?= __d('translate', 'Actions') ?></h3>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					__d('translate', 'Delete'),
 					['action' => 'delete', $translateLocale->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id), 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id),
+						],
+					],
 				)
 							?>
 				<?= $this->Html->link(__d('translate', 'List Locales'), ['action' => 'index'], ['class' => 'list-group-item list-group-item-action']) ?>

--- a/templates/Admin/TranslateLocales/index.php
+++ b/templates/Admin/TranslateLocales/index.php
@@ -57,7 +57,15 @@ use Cake\Core\Plugin;
 									<div class="btn-group" role="group">
 										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateLocale->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
 										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateLocale->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
-										<?= $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $translateLocale->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-danger', 'title' => __d('translate', 'Delete'), 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id)]) ?>
+										<?= $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $translateLocale->id], [
+											'escape' => false,
+											'class' => 'btn btn-sm btn-outline-danger',
+											'title' => __d('translate', 'Delete'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id),
+											],
+										]) ?>
 									</div>
 								</td>
 							</tr>

--- a/templates/Admin/TranslateLocales/view.php
+++ b/templates/Admin/TranslateLocales/view.php
@@ -12,7 +12,13 @@
 			</div>
 			<div class="list-group list-group-flush">
 				<?= $this->Html->link(__d('translate', 'Edit Locale'), ['action' => 'edit', $translateLocale->id], ['class' => 'list-group-item list-group-item-action']) ?>
-				<?= $this->Form->postLink(__d('translate', 'Delete Locale'), ['action' => 'delete', $translateLocale->id], ['class' => 'list-group-item list-group-item-action text-danger', 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id)]) ?>
+				<?= $this->Form->postButton(__d('translate', 'Delete Locale'), ['action' => 'delete', $translateLocale->id], [
+					'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateLocale->id),
+					],
+				]) ?>
 				<?= $this->Html->link(__d('translate', 'List Locales'), ['action' => 'index'], ['class' => 'list-group-item list-group-item-action']) ?>
 				<?= $this->Html->link(__d('translate', 'New Locale'), ['action' => 'add'], ['class' => 'list-group-item list-group-item-action']) ?>
 			</div>

--- a/templates/Admin/TranslateProjects/edit.php
+++ b/templates/Admin/TranslateProjects/edit.php
@@ -12,10 +12,17 @@
 				<i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 					['action' => 'delete', $translateProject->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),

--- a/templates/Admin/TranslateProjects/index.php
+++ b/templates/Admin/TranslateProjects/index.php
@@ -105,10 +105,18 @@ use Cake\Core\Plugin;
 											['action' => 'edit', $translateProject->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['action' => 'delete', $translateProject->id],
-											['escape' => false, 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id), 'class' => 'btn btn-outline-danger', 'title' => __d('translate', 'Delete')],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id),
+												],
+											],
 										) ?>
 									</div>
 								</td>

--- a/templates/Admin/TranslateProjects/view.php
+++ b/templates/Admin/TranslateProjects/view.php
@@ -17,10 +17,17 @@
 					['action' => 'edit', $translateProject->id],
 					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Project'),
 					['action' => 'delete', $translateProject->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateProject->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),
@@ -137,10 +144,18 @@
 											['controller' => 'TranslateDomains', 'action' => 'edit', $translateDomain->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['controller' => 'TranslateDomains', 'action' => 'delete', $translateDomain->id],
-											['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id), 'escape' => false, 'class' => 'btn btn-outline-danger', 'title' => __d('translate', 'Delete')],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateDomain->id),
+												],
+											],
 										) ?>
 									</div>
 								</td>

--- a/templates/Admin/TranslateStrings/analyze.php
+++ b/templates/Admin/TranslateStrings/analyze.php
@@ -11,6 +11,7 @@ use Cake\Core\Configure;
 
 $this->assign('title', __d('translate', 'Analyze PO File'));
 $isPreselected = $this->request->getQuery('file') !== null;
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <nav class="actions col-sm-4 col-12">
@@ -248,7 +249,7 @@ msgstr[1] "{0} Elemente"',
 												<strong><?= __d('translate', 'Suggested fix for msgid:') ?></strong>
 												<br>
 												<code class="text-success" id="fix-msgid-<?= md5($msgid . $type) ?>"><?= h($details['fixed_msgid']) ?></code>
-												<button type="button" class="btn btn-sm btn-outline-success ms-2" onclick="copyFix(this, 'fix-msgid-<?= md5($msgid . $type) ?>')" title="<?= __d('translate', 'Copy to clipboard') ?>">
+												<button type="button" class="btn btn-sm btn-outline-success ms-2" data-copy-target="fix-msgid-<?= md5($msgid . $type) ?>" title="<?= __d('translate', 'Copy to clipboard') ?>">
 													<i class="fas fa-copy"></i> <?= __d('translate', 'Copy') ?>
 												</button>
 											<?php } ?>
@@ -257,7 +258,7 @@ msgstr[1] "{0} Elemente"',
 												<strong><?= __d('translate', 'Suggested fix for msgstr:') ?></strong>
 												<br>
 												<code class="text-success" id="fix-<?= md5($msgid . $type) ?>"><?= h($details['fixed_msgstr']) ?></code>
-												<button type="button" class="btn btn-sm btn-outline-success ms-2" onclick="copyFix(this, 'fix-<?= md5($msgid . $type) ?>')" title="<?= __d('translate', 'Copy to clipboard') ?>">
+												<button type="button" class="btn btn-sm btn-outline-success ms-2" data-copy-target="fix-<?= md5($msgid . $type) ?>" title="<?= __d('translate', 'Copy to clipboard') ?>">
 													<i class="fas fa-copy"></i> <?= __d('translate', 'Copy') ?>
 												</button>
 											<?php } ?>
@@ -278,7 +279,7 @@ msgstr[1] "{0} Elemente"',
 	<?php } ?>
 </div>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 function copyFix(btn, elementId) {
 	var text = document.getElementById(elementId).textContent;
 	if (navigator.clipboard) {
@@ -306,4 +307,11 @@ function copyFix(btn, elementId) {
 		}, 2000);
 	}
 }
+
+// CSP-safe delegate: replaces inline onclick="copyFix(this, 'id')" handlers
+document.querySelectorAll('[data-copy-target]').forEach(function(btn) {
+	btn.addEventListener('click', function() {
+		copyFix(btn, btn.dataset.copyTarget);
+	});
+});
 </script>

--- a/templates/Admin/TranslateStrings/analyze.php
+++ b/templates/Admin/TranslateStrings/analyze.php
@@ -169,10 +169,10 @@ msgstr[1] "{0} Elemente"',
 						$translatedPct = round(($result['stats']['translated'] / $result['stats']['total']) * 100);
 						$untranslatedPct = 100 - $translatedPct;
 						?>
-						<div class="progress-bar bg-success" style="width: <?= $translatedPct ?>%">
+						<div class="progress-bar bg-success" data-progress-width="<?= $translatedPct ?>">
 							<?= $translatedPct ?>% <?= __d('translate', 'translated') ?>
 						</div>
-						<div class="progress-bar bg-warning" style="width: <?= $untranslatedPct ?>%">
+						<div class="progress-bar bg-warning" data-progress-width="<?= $untranslatedPct ?>">
 							<?= $untranslatedPct ?>%
 						</div>
 					</div>

--- a/templates/Admin/TranslateStrings/edit.php
+++ b/templates/Admin/TranslateStrings/edit.php
@@ -12,10 +12,17 @@
 				<i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 					['action' => 'delete', $translateString->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Strings'),

--- a/templates/Admin/TranslateStrings/extract.php
+++ b/templates/Admin/TranslateStrings/extract.php
@@ -5,6 +5,7 @@
  * @var mixed $potFiles
  * @var string $localePath
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
 	<aside class="col-md-3 col-sm-4 col-12">
@@ -71,7 +72,7 @@
 	</div>
 </div>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	document.querySelectorAll('.select-all').forEach(function(btn) {
 		btn.addEventListener('click', function() {

--- a/templates/Admin/TranslateStrings/index.php
+++ b/templates/Admin/TranslateStrings/index.php
@@ -199,10 +199,19 @@ use Cake\Core\Plugin;
 											['action' => 'edit', $translateString->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['action' => 'delete', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-danger', 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id), 'title' => __d('translate', 'Delete'), 'data-bs-toggle' => 'tooltip'],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'data-bs-toggle' => 'tooltip',
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id),
+												],
+											],
 										); ?>
 									</div>
 								</td>

--- a/templates/Admin/TranslateStrings/orphaned.php
+++ b/templates/Admin/TranslateStrings/orphaned.php
@@ -7,6 +7,7 @@
 
 use Cake\Core\Plugin;
 
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
 	<!-- Sidebar -->
@@ -142,10 +143,19 @@ use Cake\Core\Plugin;
 											['action' => 'edit', $translateString->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['action' => 'delete', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-danger', 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id), 'title' => __d('translate', 'Delete'), 'data-bs-toggle' => 'tooltip', 'block' => true],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'data-bs-toggle' => 'tooltip',
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id),
+												],
+											],
 										); ?>
 									</div>
 								</td>
@@ -181,7 +191,7 @@ use Cake\Core\Plugin;
 
 <?= $this->fetch('postLink') ?>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 // Handle bulk action buttons
 document.querySelectorAll('.bulk-action-btn').forEach(function(button) {
 	button.addEventListener('click', function(e) {

--- a/templates/Admin/TranslateStrings/translate.php
+++ b/templates/Admin/TranslateStrings/translate.php
@@ -7,7 +7,7 @@
  * @var array $braceMatches
  * @var array $sprintfMatches
  */
-
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
 	<aside class="col-md-3 col-sm-4 col-12">
@@ -172,7 +172,7 @@
 </div>
 
 <?php $this->append('script'); ?>
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 		$(function() {
 			$('ul.references').on('click', 'a.reference-link', function (e) {
 				e.preventDefault();

--- a/templates/Admin/TranslateStrings/view.php
+++ b/templates/Admin/TranslateStrings/view.php
@@ -25,10 +25,17 @@ use Cake\Core\Configure;
 					['action' => 'translate', $translateString->id],
 					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 					['action' => 'delete', $translateString->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger'],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateString->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Strings'),

--- a/templates/Admin/TranslateTerms/edit.php
+++ b/templates/Admin/TranslateTerms/edit.php
@@ -17,10 +17,17 @@ use Cake\Core\Plugin;
 				<i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
 					['action' => 'delete', $translateTerm->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger', 'block' => true],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-comments"></i> ' . __d('translate', 'List Translate Terms'),

--- a/templates/Admin/TranslateTerms/index.php
+++ b/templates/Admin/TranslateTerms/index.php
@@ -152,10 +152,18 @@ use Cake\Core\Plugin;
 											['action' => 'edit', $translateTerm->id],
 											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),
 											['action' => 'delete', $translateTerm->id],
-											['escape' => false, 'confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id), 'class' => 'btn btn-outline-danger', 'title' => __d('translate', 'Delete')],
+											[
+												'escape' => false,
+												'class' => 'btn btn-outline-danger',
+												'title' => __d('translate', 'Delete'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id),
+												],
+											],
 										) ?>
 									</div>
 								</td>

--- a/templates/Admin/TranslateTerms/pending.php
+++ b/templates/Admin/TranslateTerms/pending.php
@@ -143,13 +143,16 @@
 								['action' => 'view', $term->id],
 								['escape' => false, 'class' => 'btn btn-sm btn-info', 'title' => __d('translate', 'View')]
 							) ?>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-check"></i>',
 								['action' => 'confirm', $term->id],
 								[
 									'escapeTitle' => false,
 									'class' => 'btn btn-sm btn-success',
 									'title' => __d('translate', 'Confirm'),
+									'form' => [
+										'class' => 'd-inline',
+									],
 								]
 							) ?>
 						</td>

--- a/templates/Admin/TranslateTerms/view.php
+++ b/templates/Admin/TranslateTerms/view.php
@@ -20,10 +20,17 @@ use Cake\Core\Plugin;
 					['action' => 'edit', $translateTerm->id],
 					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Term'),
 					['action' => 'delete', $translateTerm->id],
-					['confirm' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id), 'escape' => false, 'class' => 'list-group-item list-group-item-action text-danger', 'block' => true],
+					[
+						'escape' => false,
+						'class' => 'list-group-item list-group-item-action text-danger text-start w-100',
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('translate', 'Are you sure you want to delete # {0}?', $translateTerm->id),
+						],
+					],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-comments"></i> ' . __d('translate', 'List Translate Terms'),

--- a/templates/Translate/index.php
+++ b/templates/Translate/index.php
@@ -41,7 +41,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							<div class="flex-grow-1 ms-3">
 								<h5 class="mb-1"><?= __d('translate', 'Current Translation Coverage') ?></h5>
 								<p class="mb-0">
-									<span style="color:#<?= $totalColor; ?>;font-weight:bold;font-size:2rem;">
+									<span class="fw-bold fs-1" data-text-color="#<?= $totalColor; ?>">
 										<?= $totalCoverage ?>%
 									</span>
 									<span class="text-muted"><?= __d('translate', 'translated') ?></span>
@@ -142,7 +142,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 										<div class="text-end">
 											<div class="progress" style="width: 100px; height: 20px;">
-												<div class="progress-bar bg-' . $progressColor . '" role="progressbar" style="width: ' . $percentage . '%">
+												<div class="progress-bar bg-' . $progressColor . '" role="progressbar" data-progress-width="' . $percentage . '">
 													' . $percentage . '%
 												</div>
 											</div>

--- a/templates/Translate/translate.php
+++ b/templates/Translate/translate.php
@@ -47,7 +47,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 								<div class="progress mt-2" style="height: 5px;">
 									<div class="progress-bar bg-success"
 										role="progressbar"
-										style="width: <?= $stats['percentage'] ?>%"
+										data-progress-width="<?= $stats['percentage'] ?>"
 										aria-valuenow="<?= $stats['percentage'] ?>"
 										aria-valuemin="0"
 										aria-valuemax="100">

--- a/templates/Translate/translate.php
+++ b/templates/Translate/translate.php
@@ -6,7 +6,7 @@
  * @var array $suggestions
  * @var array $domainStats
  */
-
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!-- Domain Navigation -->
 <div class="mb-4">
@@ -183,7 +183,7 @@ References: <?php echo count($references)?>x
 </div>
 
 <?php $this->append('script'); ?>
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 		$(function() {
 			$('ul.references').on('click', 'a.reference-link', function (e) {
 				e.preventDefault();

--- a/templates/element/coverage_table.php
+++ b/templates/element/coverage_table.php
@@ -19,7 +19,7 @@
 	?>
 <tr>
 	<td><?php echo $this->Translation->flag($this->Translation->resolveFlagCode($language)); ?> <?php echo h($language->locale); ?></td>
-	<td><span style="color:#<?php echo $currentColor;?>;font-weight:bold"><?php echo $currentCoverage; ?>%</span></td>
+	<td><span class="fw-bold" data-text-color="#<?php echo $currentColor; ?>"><?php echo $currentCoverage; ?>%</span></td>
 	<td><?= $stats['translated'] ?> / <?= $stats['total'] ?></td>
 </tr>
 <?php } ?>

--- a/templates/element/suggestions.php
+++ b/templates/element/suggestions.php
@@ -10,6 +10,7 @@ if (!$suggestions) {
 	return;
 }
 
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 $suggestionsArray = [];
 foreach ($suggestions as $engine => $suggestion) {
 	$engineName = substr($engine, strrpos($engine, '\\') + 1);
@@ -57,7 +58,7 @@ $target = 'content-' . $key;
 </style>
 
 <?php $this->append('script'); ?>
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	$(function() {
 		$('.suggest[rel="<?php echo $key; ?>"]').click(function() {
 			var input = $('#<?php echo $target; ?>');

--- a/templates/layout/simple.php
+++ b/templates/layout/simple.php
@@ -326,6 +326,16 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			popoverTriggerList.map(function (popoverTriggerEl) {
 				return new bootstrap.Popover(popoverTriggerEl);
 			});
+
+			// CSP-safe replacement for inline style="width:N%": apply data-progress-width to .style.width
+			document.querySelectorAll('[data-progress-width]').forEach(function (el) {
+				el.style.width = el.dataset.progressWidth + '%';
+			});
+
+			// CSP-safe replacement for inline style="color:#XYZ": apply data-text-color to .style.color
+			document.querySelectorAll('[data-text-color]').forEach(function (el) {
+				el.style.color = el.dataset.textColor;
+			});
 		});
 	</script>
 

--- a/templates/layout/simple.php
+++ b/templates/layout/simple.php
@@ -5,6 +5,7 @@
  */
 
 $title = $this->fetch('title');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -293,7 +294,7 @@ $title = $this->fetch('title');
 	<!-- Bootstrap Bundle (includes Popper) -->
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 		$(document).ready(function() {
 			// Add loading state to buttons on form submit
 			$('form').on('submit', function() {
@@ -304,14 +305,14 @@ $title = $this->fetch('title');
 				}
 			});
 
-			// Confirm delete actions
-			$('.btn-danger, a[href*="delete"]').on('click', function(e) {
-				if ($(this).data('confirm') !== false) {
-					if (!confirm('Are you sure you want to delete this item?')) {
+			// Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+			document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+				form.addEventListener('submit', function(e) {
+					if (!confirm(form.dataset.confirmMessage)) {
 						e.preventDefault();
-						return false;
+						e.stopImmediatePropagation();
 					}
-				}
+				});
 			});
 
 			// Initialize Bootstrap tooltips

--- a/tests/test_app/templates/Error/error400.php
+++ b/tests/test_app/templates/Error/error400.php
@@ -7,7 +7,7 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
-if (Configure::read('debug')) :
+if (Configure::read('debug')) {
 	$this->layout = 'dev_error';
 
 	$this->assign('title', $message);
@@ -15,25 +15,25 @@ if (Configure::read('debug')) :
 
 	$this->start('file');
 	?>
-	<?php if (!empty($error->queryString)) : ?>
+	<?php if (!empty($error->queryString)) { ?>
 	<p class="notice">
 		<strong>SQL Query: </strong>
 		<?= h($error->queryString) ?>
 	</p>
-    <?php endif; ?>
-	<?php if (!empty($error->params)) : ?>
+    <?php } ?>
+	<?php if (!empty($error->params)) { ?>
 		<strong>SQL Query Params: </strong>
 		<?= Debugger::dump($error->params) ?>
-    <?php endif; ?>
+    <?php } ?>
 	<?php
 	echo $this->element('auto_table_warning');
 
-	if (extension_loaded('xdebug')) :
+	if (extension_loaded('xdebug')) {
 		xdebug_print_function_stack();
-	endif;
+	}
 
 	$this->end();
-endif;
+}
 ?>
 <h2><?= __d('cake', '404') ?></h2>
 <p class="error">

--- a/tests/test_app/templates/Error/error500.php
+++ b/tests/test_app/templates/Error/error500.php
@@ -7,7 +7,7 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
-if (Configure::read('debug')) :
+if (Configure::read('debug')) {
 	$this->layout = 'dev_error';
 
 	$this->assign('title', $message);
@@ -15,25 +15,25 @@ if (Configure::read('debug')) :
 
 	$this->start('file');
 	?>
-	<?php if (!empty($error->queryString)) : ?>
+	<?php if (!empty($error->queryString)) { ?>
 	<p class="notice">
 		<strong>SQL Query: </strong>
 		<?= h($error->queryString) ?>
 	</p>
-    <?php endif; ?>
-	<?php if (!empty($error->params)) : ?>
+    <?php } ?>
+	<?php if (!empty($error->params)) { ?>
 		<strong>SQL Query Params: </strong>
 		<?= Debugger::dump($error->params) ?>
-    <?php endif; ?>
+    <?php } ?>
 	<?php
 	echo $this->element('auto_table_warning');
 
-	if (extension_loaded('xdebug')) :
+	if (extension_loaded('xdebug')) {
 		xdebug_print_function_stack();
-	endif;
+	}
 
 	$this->end();
-endif;
+}
 ?>
 <h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
 <p class="error">


### PR DESCRIPTION
## Summary

- Add nonce to 11 inline `<script>` blocks (layout, user-facing translate page, suggestions element, and 8 admin templates).
- Replace 6 inline `onclick=""` handlers with `data-action` attributes + delegated click listeners (CSP does not allow nonce on inline event handlers).
- Replace 28 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message`.
- Update the layout's existing submit delegate to hook `form[data-confirm-message]` (the postButton-compatible selector).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- **Layout (`templates/layout/simple.php`)**: add `nonce` to the inline script; switch the submit delegate from the legacy `form[data-confirm]` to `form[data-confirm-message]` (the postButton-compatible hook). No templates used the old selector.
- **Inline scripts**: add `nonce` to `element/suggestions.php`, `Translate/translate.php`, `Admin/TranslateStrings/{analyze,extract,orphaned,translate}.php`, `Admin/I18nEntries/{entries,edit,entries_base}.php`, `Admin/TranslateBehavior/generate.php` (11 `<script>` blocks total).
- **Inline event handlers removed**:
  - `analyze.php`: `onclick="copyFix(this, 'id')"` -> `data-copy-target="id"` + delegate.
  - `entries_base.php`: `onclick="return confirmBatch()"` -> `data-action="confirm-batch"` + delegate.
  - `TranslateBehavior/generate.php`: `onclick="selectAll()"`, `onclick="deselectAll()"`, `onclick="copyToClipboard()"` -> `data-action="fields-select-all"` / `fields-deselect-all` / `copy-migration` + delegates.
- **postLink migration**: 28 calls across TranslateDomains, TranslateLocales, TranslateTerms, TranslateApiTranslations, TranslateStrings, TranslateProjects, Translate (reset), and I18nEntries. Class stays link-styled where appropriate (`list-group-item ...` or `btn btn-link ...`), plus `form` is set to `d-inline` / `d-grid` to keep the layout consistent.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <button type="submit" class="btn btn-info btn-sm" onclick="return confirmBatch()">
+ <button type="submit" class="btn btn-info btn-sm" data-action="confirm-batch">
```

```diff
- <?= $this->Form->postLink('<i class="fas fa-trash"></i>', [...], [
-     'class' => 'btn btn-outline-danger',
-     'confirm' => __d('translate', 'Sure?'),
-     'block' => true,
- ]) ?>
+ <?= $this->Form->postButton('<i class="fas fa-trash"></i>', [...], [
+     'class' => 'btn btn-outline-danger',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => __d('translate', 'Sure?'),
+     ],
+ ]) ?>
```

Note: the btn-group rows on index/orphaned still render correctly because the postButton form uses `class="d-inline"` inside the `.btn-group`.
