### PR TITLE
Drop last inline styles for strict-CSP (data-style + JS shim)

### DIFF
--- a/templates/Admin/I18nEntries/edit.php
+++ b/templates/Admin/I18nEntries/edit.php
@@ -67,7 +67,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 							<i class="fas fa-file-alt"></i> <?= __d('translate', 'Source Text') ?>
 							<small class="text-muted">(<?= __d('translate', 'original') ?>)</small>
 						</label>
-						<div class="form-control bg-light" style="min-height: 80px; white-space: pre-wrap;">
+						<div class="form-control bg-light" data-style="min-height: 80px; white-space: pre-wrap;">
 							<?= h($sourceText) ?>
 						</div>
 					</div>

--- a/templates/Admin/I18nEntries/entries.php
+++ b/templates/Admin/I18nEntries/entries.php
@@ -150,7 +150,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<table class="table table-striped table-hover mb-0">
 						<thead class="table-light">
 							<tr>
-								<th style="width: 40px;">
+								<th data-style="width: 40px;">
 									<input type="checkbox" id="check-all" class="form-check-input">
 								</th>
 								<th><?= __d('translate', 'ID') ?></th>

--- a/templates/Admin/I18nEntries/entries_base.php
+++ b/templates/Admin/I18nEntries/entries_base.php
@@ -89,9 +89,9 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<label for="select-all" class="form-check-label"><?= __d('translate', 'Select All') ?></label>
 				</div>
 				<div class="d-flex align-items-center gap-2">
-					<div class="input-group input-group-sm" style="width: auto;">
+					<div class="input-group input-group-sm" data-style="width: auto;">
 						<span class="input-group-text"><?= __d('translate', 'Locales') ?></span>
-						<select name="locales[]" multiple class="form-select form-select-sm" style="min-width: 150px;" id="locale-select">
+						<select name="locales[]" multiple class="form-select form-select-sm" data-style="min-width: 150px;" id="locale-select">
 							<?php foreach ($locales as $locale) { ?>
 								<option value="<?= h($locale) ?>" selected><?= h($locale) ?></option>
 							<?php } ?>
@@ -107,7 +107,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<table class="table table-striped table-hover mb-0">
 						<thead class="table-light">
 							<tr>
-								<th style="width: 40px;"></th>
+								<th data-style="width: 40px;"></th>
 								<th><?= __d('translate', 'ID') ?></th>
 								<?php if ($displayField) { ?>
 									<th><?= h(ucfirst($displayField)) ?></th>

--- a/templates/Admin/I18nEntries/index.php
+++ b/templates/Admin/I18nEntries/index.php
@@ -69,7 +69,7 @@
 					<div class="card-body">
 						<dl class="row mb-0">
 							<dt class="col-6"><?= __d('translate', 'Table') ?>:</dt>
-							<dd class="col-6"><code style="font-size: 0.75rem;"><?= h($tableName) ?></code></dd>
+							<dd class="col-6"><code data-style="font-size: 0.75rem;"><?= h($tableName) ?></code></dd>
 
 							<dt class="col-6"><?= __d('translate', 'Strategy') ?>:</dt>
 							<dd class="col-6">

--- a/templates/Admin/I18nEntries/translation_form.php
+++ b/templates/Admin/I18nEntries/translation_form.php
@@ -150,7 +150,7 @@ $isNew = $translation->isNew();
 				<?php foreach ($translatedFields as $field) { ?>
 					<div class="mb-2">
 						<strong><?= h(ucfirst($field)) ?>:</strong>
-						<div class="border rounded p-2 bg-light" style="max-height: 150px; overflow-y: auto;">
+						<div class="border rounded p-2 bg-light" data-style="max-height: 150px; overflow-y: auto;">
 							<?php
 							$value = $baseRecord->$field ?? '';
 							if ($value) {

--- a/templates/Admin/I18nEntries/view_record.php
+++ b/templates/Admin/I18nEntries/view_record.php
@@ -133,7 +133,7 @@
 											<?php
 											$value = $translation->$field ?? '';
 											if ($value) {
-												echo '<div class="text-break" style="max-width: 400px;">' . h($value) . '</div>';
+												echo '<div class="text-break" data-style="max-width: 400px;">' . h($value) . '</div>';
 											} else {
 												echo '<span class="text-muted">(' . __d('translate', 'empty') . ')</span>';
 											}

--- a/templates/Admin/Translate/index.php
+++ b/templates/Admin/Translate/index.php
@@ -90,7 +90,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 					</div>
 					<?php } ?>
 					<div class="col-md-2 text-end">
-						<span class="badge bg-success" style="font-size: 1.5rem; padding: 0.5rem 1rem;">
+						<span class="badge bg-success" data-style="font-size: 1.5rem; padding: 0.5rem 1rem;">
 							<i class="fas fa-chart-pie"></i> <?= $totalCoverage ?>%
 						</span>
 						<small class="text-muted d-block"><?= __d('translate', 'Overall Coverage') ?></small>
@@ -153,7 +153,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<span class="badge bg-secondary"><?= number_format($stats['unconfirmed']) ?></span>
 							</td>
 							<td>
-								<div class="progress" style="height: 20px;">
+								<div class="progress" data-style="height: 20px;">
 									<div class="progress-bar <?= $stats['percentage'] >= 80 ? 'bg-success' : ($stats['percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 										role="progressbar"
 										data-progress-width="<?= $stats['percentage'] ?>"
@@ -373,13 +373,13 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 											<small><strong><?= __d('translate', 'Unified Diff') ?></strong></small>
 										</div>
 										<div class="card-body p-0">
-											<pre class="mb-0" style="background: #f8f9fa; padding: 10px; border: none; font-size: 12px; line-height: 1.4;"><code><?php
+											<pre class="mb-0" data-style="background: #f8f9fa; padding: 10px; border: none; font-size: 12px; line-height: 1.4;"><code><?php
 											// Generate unified diff style output
 											$oldLines = explode("\n", $oldData['content']);
 											$newLines = explode("\n", $term->content);
 
 											// Show context header
-											echo '<span style="color: #999;">@@ Translation @@</span>' . "\n";
+											echo '<span data-style="color: #999;">@@ Translation @@</span>' . "\n";
 
 											// Simple line-by-line diff
 											$maxLines = max(count($oldLines), count($newLines));
@@ -389,10 +389,10 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 
 												if ($oldLine !== $newLine) {
 													if ($oldLine !== '') {
-														echo '<span style="background: #ffdddd; color: #d00;">-' . h($oldLine) . '</span>' . "\n";
+														echo '<span data-style="background: #ffdddd; color: #d00;">-' . h($oldLine) . '</span>' . "\n";
 													}
 													if ($newLine !== '') {
-														echo '<span style="background: #ddffdd; color: #080;">+' . h($newLine) . '</span>' . "\n";
+														echo '<span data-style="background: #ddffdd; color: #080;">+' . h($newLine) . '</span>' . "\n";
 													}
 												} else {
 													echo ' ' . h($oldLine) . "\n";
@@ -609,7 +609,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 						<div class="card-body p-2">
 							<table class="table table-sm table-bordered mb-0">
 								<tr>
-									<th style="width: 30%;"><?= __d('translate', 'Timestamp') ?></th>
+									<th data-style="width: 30%;"><?= __d('translate', 'Timestamp') ?></th>
 									<td><?= $this->Time->nice($log->created) ?></td>
 								</tr>
 								<tr>
@@ -639,7 +639,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							<small><strong><?= __d('translate', 'Unified Diff') ?></strong></small>
 						</div>
 						<div class="card-body p-0">
-							<pre class="mb-0" style="background: #f8f9fa; padding: 10px; border: none; font-size: 12px; line-height: 1.4;"><code><?php
+							<pre class="mb-0" data-style="background: #f8f9fa; padding: 10px; border: none; font-size: 12px; line-height: 1.4;"><code><?php
 							// Generate unified diff for each changed field
 							foreach ($newData as $field => $newValue) {
 								$oldValue = $oldData[$field] ?? null;
@@ -650,7 +650,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								}
 
 								// Show field header
-								echo '<span style="color: #999;">@@ ' . h($field) . ' @@</span>' . "\n";
+								echo '<span data-style="color: #999;">@@ ' . h($field) . ' @@</span>' . "\n";
 
 								// Convert to string for comparison
 								$oldStr = is_array($oldValue) ? json_encode($oldValue) : (string)$oldValue;
@@ -667,10 +667,10 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 
 									if ($oldLine !== $newLine) {
 										if ($oldLine !== '') {
-											echo '<span style="background: #ffdddd; color: #d00;">-' . h($oldLine) . '</span>' . "\n";
+											echo '<span data-style="background: #ffdddd; color: #d00;">-' . h($oldLine) . '</span>' . "\n";
 										}
 										if ($newLine !== '') {
-											echo '<span style="background: #ddffdd; color: #080;">+' . h($newLine) . '</span>' . "\n";
+											echo '<span data-style="background: #ddffdd; color: #080;">+' . h($newLine) . '</span>' . "\n";
 										}
 									} else {
 										echo ' ' . h($oldLine) . "\n";
@@ -693,9 +693,9 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							<table class="table table-sm table-bordered mb-0">
 								<thead>
 									<tr>
-										<th style="width: 20%;"><?= __d('translate', 'Field') ?></th>
-										<th style="width: 40%;"><?= __d('translate', 'Before') ?></th>
-										<th style="width: 40%;"><?= __d('translate', 'After') ?></th>
+										<th data-style="width: 20%;"><?= __d('translate', 'Field') ?></th>
+										<th data-style="width: 40%;"><?= __d('translate', 'Before') ?></th>
+										<th data-style="width: 40%;"><?= __d('translate', 'After') ?></th>
 									</tr>
 								</thead>
 								<tbody>
@@ -742,8 +742,8 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							<table class="table table-sm table-bordered mb-0">
 								<thead>
 									<tr>
-										<th style="width: 30%;"><?= __d('translate', 'Field') ?></th>
-										<th style="width: 70%;"><?= __d('translate', 'Value') ?></th>
+										<th data-style="width: 30%;"><?= __d('translate', 'Field') ?></th>
+										<th data-style="width: 70%;"><?= __d('translate', 'Value') ?></th>
 									</tr>
 								</thead>
 								<tbody>

--- a/templates/Admin/Translate/stats.php
+++ b/templates/Admin/Translate/stats.php
@@ -31,7 +31,7 @@
 			<div class="card-body">
 				<div class="mb-3">
 					<strong><?= __d('translate', 'Translation Progress') ?></strong>
-					<div class="progress mt-1" style="height: 25px;">
+					<div class="progress mt-1" data-style="height: 25px;">
 						<div class="progress-bar <?= $grandTotal['translation_percentage'] >= 80 ? 'bg-success' : ($grandTotal['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 							role="progressbar"
 							data-progress-width="<?= $grandTotal['translation_percentage'] ?>"
@@ -48,7 +48,7 @@
 
 				<div>
 					<strong><?= __d('translate', 'Confirmation Progress') ?></strong>
-					<div class="progress mt-1" style="height: 25px;">
+					<div class="progress mt-1" data-style="height: 25px;">
 						<div class="progress-bar bg-info"
 							role="progressbar"
 							data-progress-width="<?= $grandTotal['confirmation_percentage'] ?>"
@@ -106,8 +106,8 @@
 										<span class="badge bg-secondary">0</span>
 									<?php } ?>
 								</td>
-								<td style="min-width: 150px;">
-									<div class="progress" style="height: 20px;">
+								<td data-style="min-width: 150px;">
+									<div class="progress" data-style="height: 20px;">
 										<div class="progress-bar <?= $data['translation_percentage'] >= 80 ? 'bg-success' : ($data['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 											role="progressbar"
 											data-progress-width="<?= $data['translation_percentage'] ?>"
@@ -128,8 +128,8 @@
 										<span class="badge bg-secondary">0</span>
 									<?php } ?>
 								</td>
-								<td style="min-width: 150px;">
-									<div class="progress" style="height: 20px;">
+								<td data-style="min-width: 150px;">
+									<div class="progress" data-style="height: 20px;">
 										<div class="progress-bar bg-info"
 											role="progressbar"
 											data-progress-width="<?= $data['confirmation_percentage'] ?>"
@@ -191,8 +191,8 @@
 										<span class="badge bg-secondary">0</span>
 									<?php } ?>
 								</td>
-								<td style="min-width: 120px;">
-									<div class="progress" style="height: 18px;">
+								<td data-style="min-width: 120px;">
+									<div class="progress" data-style="height: 18px;">
 										<div class="progress-bar <?= $stat['translation_percentage'] >= 80 ? 'bg-success' : ($stat['translation_percentage'] >= 50 ? 'bg-warning' : 'bg-danger') ?>"
 											role="progressbar"
 											data-progress-width="<?= $stat['translation_percentage'] ?>"
@@ -213,8 +213,8 @@
 										<span class="badge bg-secondary">0</span>
 									<?php } ?>
 								</td>
-								<td style="min-width: 120px;">
-									<div class="progress" style="height: 18px;">
+								<td data-style="min-width: 120px;">
+									<div class="progress" data-style="height: 18px;">
 										<div class="progress-bar bg-info"
 											role="progressbar"
 											data-progress-width="<?= $stat['confirmation_percentage'] ?>"

--- a/templates/Admin/TranslateBehavior/generate.php
+++ b/templates/Admin/TranslateBehavior/generate.php
@@ -101,7 +101,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 							'default' => 'shadow_table',
 						]) ?>
 
-						<div class="alert alert-info mt-2" style="font-size: 0.85rem;">
+						<div class="alert alert-info mt-2" data-style="font-size: 0.85rem;">
 							<strong>Shadow Table:</strong> <?= __d('translate', 'Creates columns for each field. Better performance, recommended.') ?><br>
 							<strong>EAV:</strong> <?= __d('translate', 'Flexible, stores each field translation as a row. More flexible but slower.') ?>
 						</div>
@@ -137,7 +137,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 								<?= __d('translate', 'No translatable fields found in this table.') ?>
 							</div>
 						<?php } else { ?>
-							<div class="border rounded p-2" style="max-height: 300px; overflow-y: auto;">
+							<div class="border rounded p-2" data-style="max-height: 300px; overflow-y: auto;">
 								<?php foreach ($translatableFields as $field) { ?>
 									<div class="form-check">
 										<input type="checkbox"
@@ -184,11 +184,11 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<h6 class="mb-0"><i class="fas fa-check-circle"></i> <?= __d('translate', 'Next Steps') ?></h6>
 				</div>
 				<div class="card-body">
-					<ol class="mb-0" style="font-size: 0.9rem;">
+					<ol class="mb-0" data-style="font-size: 0.9rem;">
 						<li><?= __d('translate', 'Copy the migration code') ?></li>
 						<li>
 							<?= __d('translate', 'Save to') ?>
-							<br><code style="font-size: 0.75rem;">config/Migrations/<br><?= h($migrationName) ?>.php</code>
+							<br><code data-style="font-size: 0.75rem;">config/Migrations/<br><?= h($migrationName) ?>.php</code>
 						</li>
 						<li>
 							<?= __d('translate', 'Run:') ?>
@@ -196,7 +196,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 						</li>
 						<li>
 							<?= __d('translate', 'Add to your Table class:') ?>
-							<pre style="font-size: 0.75rem; background: #f8f9fa; padding: 0.5rem; margin-top: 0.5rem;"><code><?php
+							<pre data-style="font-size: 0.75rem; background: #f8f9fa; padding: 0.5rem; margin-top: 0.5rem;"><code><?php
 // Format fields array with proper indentation
 $fields = array_values($selectedFields);
 $fieldsFormatted = "[\n";
@@ -230,7 +230,7 @@ $fieldsFormatted .= "        ]";
 						</h6>
 					</div>
 					<div class="card-body p-0">
-						<pre class="mb-0 p-3" style="background: #2d2d2d; color: #f8f8f2; border-radius: 0; max-height: 600px; overflow-y: auto;"><code><?= h($migrationCode) ?></code></pre>
+						<pre class="mb-0 p-3" data-style="background: #2d2d2d; color: #f8f8f2; border-radius: 0; max-height: 600px; overflow-y: auto;"><code><?= h($migrationCode) ?></code></pre>
 					</div>
 					<div class="card-footer">
 						<button type="button" class="btn btn-sm btn-outline-primary" data-action="copy-migration">

--- a/templates/Admin/TranslateBehavior/view.php
+++ b/templates/Admin/TranslateBehavior/view.php
@@ -168,7 +168,7 @@
 			</div>
 			<div class="card-body p-0">
 				<div class="table-responsive">
-					<table class="table table-sm table-striped table-hover mb-0" style="font-size: 0.85rem;">
+					<table class="table table-sm table-striped table-hover mb-0" data-style="font-size: 0.85rem;">
 						<thead class="table-light">
 							<tr>
 								<?php foreach (array_keys($sampleData[0] ?? []) as $columnName) { ?>
@@ -235,7 +235,7 @@
 						<i class="fas fa-exclamation-triangle"></i>
 						<strong><?= __d('translate', 'Note') ?>:</strong>
 						<?= __d('translate', 'The model class exists but doesn\'t have the TranslateBehavior attached. Add it to your Table class:') ?>
-						<pre class="mt-2 mb-0" style="background: #f8f9fa; padding: 0.5rem;"><code><?php
+						<pre class="mt-2 mb-0" data-style="background: #f8f9fa; padding: 0.5rem;"><code><?php
 // Format fields array with proper indentation
 $fields = array_values($translatedFields);
 $fieldsFormatted = "[\n";

--- a/templates/Admin/TranslateStrings/analyze.php
+++ b/templates/Admin/TranslateStrings/analyze.php
@@ -164,7 +164,7 @@ msgstr[1] "{0} Elemente"',
 				</div>
 
 				<?php if ($result['stats']['total'] > 0) { ?>
-					<div class="progress mt-3" style="height: 25px;">
+					<div class="progress mt-3" data-style="height: 25px;">
 						<?php
 						$translatedPct = round(($result['stats']['translated'] / $result['stats']['total']) * 100);
 						$untranslatedPct = 100 - $translatedPct;

--- a/templates/Admin/TranslateStrings/run_extract.php
+++ b/templates/Admin/TranslateStrings/run_extract.php
@@ -158,7 +158,7 @@ $this->assign('title', __d('translate', 'Run i18n Extract (Experimental)'));
 					</span>
 				</div>
 				<div class="card-body">
-					<pre class="mb-0" style="max-height: 400px; overflow-y: auto;"><?= h($output) ?></pre>
+					<pre class="mb-0" data-style="max-height: 400px; overflow-y: auto;"><?= h($output) ?></pre>
 				</div>
 			</div>
 		<?php } ?>
@@ -178,7 +178,7 @@ $this->assign('title', __d('translate', 'Run i18n Extract (Experimental)'));
 								<span class="badge bg-primary"><?= __d('translate', '{0} strings', $data['count']) ?></span>
 							</div>
 							<div class="card-body p-0">
-								<pre class="mb-0 p-3" style="max-height: 300px; overflow-y: auto; font-size: 0.8rem;"><?= h($data['content']) ?></pre>
+								<pre class="mb-0 p-3" data-style="max-height: 300px; overflow-y: auto; font-size: 0.8rem;"><?= h($data['content']) ?></pre>
 							</div>
 						</div>
 					<?php } ?>

--- a/templates/Admin/TranslateStrings/source.php
+++ b/templates/Admin/TranslateStrings/source.php
@@ -8,7 +8,7 @@
 	<div class="card-header">
 		<h3 class="card-title"><i class="fa-solid fa-file-code"></i> <?= __d('translate', 'Source Code') ?></h3>
 	</div>
-	<div class="card-body" style="max-height:500px;overflow:auto">
+	<div class="card-body" data-style="max-height:500px;overflow:auto">
 		<?php
 		highlight_file($sourceFile);
 		?>

--- a/templates/Admin/TranslateStrings/view.php
+++ b/templates/Admin/TranslateStrings/view.php
@@ -64,7 +64,7 @@ use Cake\Core\Configure;
 			<div class="card-body">
 				<h5 class="text-muted mb-3"><?= __d('translate', 'Original String') ?></h5>
 				<div class="alert alert-light border mb-4">
-					<pre class="mb-0" style="white-space: pre-wrap;"><?= h($translateString->name) ?></pre>
+					<pre class="mb-0" data-style="white-space: pre-wrap;"><?= h($translateString->name) ?></pre>
 				</div>
 
 				<div class="row g-3">

--- a/templates/Translate/index.php
+++ b/templates/Translate/index.php
@@ -141,7 +141,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 											<small class="text-muted">' . $data['translated'] . ' / ' . $data['total'] . ' ' . __d('translate', 'translated') . '</small>
 										</div>
 										<div class="text-end">
-											<div class="progress" style="width: 100px; height: 20px;">
+											<div class="progress" data-style="width: 100px; height: 20px;">
 												<div class="progress-bar bg-' . $progressColor . '" role="progressbar" data-progress-width="' . $percentage . '">
 													' . $percentage . '%
 												</div>

--- a/templates/Translate/translate.php
+++ b/templates/Translate/translate.php
@@ -44,7 +44,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 									<?= $stats['translated'] ?> / <?= $stats['total'] ?>
 									<?= __d('translate', 'strings') ?>
 								</small>
-								<div class="progress mt-2" style="height: 5px;">
+								<div class="progress mt-2" data-style="height: 5px;">
 									<div class="progress-bar bg-success"
 										role="progressbar"
 										data-progress-width="<?= $stats['percentage'] ?>"

--- a/templates/layout/simple.php
+++ b/templates/layout/simple.php
@@ -336,6 +336,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			document.querySelectorAll('[data-text-color]').forEach(function (el) {
 				el.style.color = el.dataset.textColor;
 			});
+
+			// CSP-safe replacement for inline style="...": apply data-style to .style.cssText.
+			// JS-driven style mutation is not subject to style-src 'unsafe-inline'.
+			document.querySelectorAll('[data-style]').forEach(function (el) {
+				el.style.cssText = el.dataset.style;
+			});
 		});
 	</script>
 


### PR DESCRIPTION
Continuation of #47. Converts every remaining inline `style="..."` attribute (51 across 17 templates — mostly static heights, widths, max-heights, font-sizes from `TranslateBehavior`, `TranslateStrings`, `Translate/Stats`, `I18nEntries`) into `data-style="..."`. The layout's existing nonced `<script>` reads `[data-style]` and assigns `el.style.cssText` — JS-driven style mutation is not subject to `style-src 'unsafe-inline'`. After this PR templates have zero inline `style=` attributes.