### PR TITLE
Add Detected Domains analyzer (project + plugins/ scanner)

### DIFF
--- a/src/Controller/Admin/TranslateController.php
+++ b/src/Controller/Admin/TranslateController.php
@@ -668,16 +668,17 @@ class TranslateController extends TranslateAppController {
 		$importedDomainNames = [];
 		$importedStringCounts = [];
 		if ($projectId && $detected) {
+			/** @var array<\Translate\Model\Entity\TranslateDomain> $translateDomains */
 			$translateDomains = $this->TranslateDomains->find()
 				->where([
 					'TranslateDomains.translate_project_id' => $projectId,
 					'TranslateDomains.name IN' => array_keys($detected),
 				])
 				->contain(['TranslateStrings'])
-				->all();
+				->toArray();
 			foreach ($translateDomains as $td) {
 				$importedDomainNames[$td->name] = true;
-				$importedStringCounts[$td->name] = is_array($td->translate_strings) ? count($td->translate_strings) : 0;
+				$importedStringCounts[$td->name] = count($td->translate_strings);
 			}
 		}
 
@@ -719,6 +720,7 @@ class TranslateController extends TranslateAppController {
 		foreach ($detected as $domain => $info) {
 			$coverage = [];
 			foreach ($availableLocales as $locale) {
+				$locale = (string)$locale;
 				$found = null;
 				// Check the locale itself, then its parent language (e.g. de_DE → de)
 				$candidates = [$locale];
@@ -730,6 +732,7 @@ class TranslateController extends TranslateAppController {
 						$candidate = rtrim($lp, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $loc . DIRECTORY_SEPARATOR . $domain . '.po';
 						if (is_file($candidate)) {
 							$found = $candidate;
+
 							break 2;
 						}
 					}
@@ -741,6 +744,7 @@ class TranslateController extends TranslateAppController {
 				$candidate = rtrim($lp, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $domain . '.pot';
 				if (is_file($candidate)) {
 					$potFile = $candidate;
+
 					break;
 				}
 			}
@@ -751,6 +755,7 @@ class TranslateController extends TranslateAppController {
 			foreach ($coverage as $po) {
 				if ($po) {
 					$hasAnyPo = true;
+
 					break;
 				}
 			}

--- a/src/Controller/Admin/TranslateController.php
+++ b/src/Controller/Admin/TranslateController.php
@@ -663,6 +663,24 @@ class TranslateController extends TranslateAppController {
 		$paths = $scanner->discoverPaths($projectPath);
 		$detected = $scanner->scan($paths);
 
+		// Which detected domains already have a TranslateDomain row (and therefore
+		// strings imported into the DB) for the current project?
+		$importedDomainNames = [];
+		$importedStringCounts = [];
+		if ($projectId && $detected) {
+			$translateDomains = $this->TranslateDomains->find()
+				->where([
+					'TranslateDomains.translate_project_id' => $projectId,
+					'TranslateDomains.name IN' => array_keys($detected),
+				])
+				->contain(['TranslateStrings'])
+				->all();
+			foreach ($translateDomains as $td) {
+				$importedDomainNames[$td->name] = true;
+				$importedStringCounts[$td->name] = is_array($td->translate_strings) ? count($td->translate_strings) : 0;
+			}
+		}
+
 		// Determine app locale paths to check coverage against
 		$localePaths = (array)Configure::read('App.paths.locales', []);
 		if (!$localePaths) {
@@ -726,6 +744,43 @@ class TranslateController extends TranslateAppController {
 					break;
 				}
 			}
+			$hasImportedStrings = !empty($importedDomainNames[$domain]);
+			$importedCount = $importedStringCounts[$domain] ?? 0;
+			$hasDefaultPo = !empty($coverage[$normalizedDefault]);
+			$hasAnyPo = false;
+			foreach ($coverage as $po) {
+				if ($po) {
+					$hasAnyPo = true;
+					break;
+				}
+			}
+
+			// Pipeline stage. The load-bearing thing for the silent-fallback bug
+			// is whether a default-locale .po file exists at runtime — that's
+			// what CakePHP's I18n actually loads. The DB-strings check only
+			// matters for plugin's own translate-in-DB workflow.
+			//
+			//   default — special-case: the `default` domain is handled by the
+			//             app's own default.po; nothing this analyzer needs to do.
+			//   covered — default-locale .po exists. Silent fallback is broken;
+			//             user is safe regardless of DB pipeline state.
+			//   dump    — DB has translated strings but no app-level .po yet —
+			//             one click to write them to disk.
+			//   import  — .pot exists but no DB strings for this domain yet —
+			//             load the .pot into the DB and translate.
+			//   extract — nothing exists yet — start from scratch.
+			if ($domain === 'default') {
+				$stage = 'default';
+			} elseif ($hasDefaultPo) {
+				$stage = 'covered';
+			} elseif ($hasImportedStrings) {
+				$stage = 'dump';
+			} elseif ($potFile) {
+				$stage = 'import';
+			} else {
+				$stage = 'extract';
+			}
+
 			$domainsReport[$domain] = [
 				'msgidCount' => count($info['msgids']),
 				'callCount' => $info['callCount'],
@@ -735,6 +790,9 @@ class TranslateController extends TranslateAppController {
 				'coverage' => $coverage,
 				'potFile' => $potFile,
 				'isDefaultDomain' => $domain === 'default',
+				'hasImportedStrings' => $hasImportedStrings,
+				'importedStringCount' => $importedCount,
+				'stage' => $stage,
 			];
 		}
 

--- a/src/Controller/Admin/TranslateController.php
+++ b/src/Controller/Admin/TranslateController.php
@@ -2,6 +2,7 @@
 
 namespace Translate\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use Cake\View\JsonView;
@@ -10,6 +11,7 @@ use DirectoryIterator;
 use Exception;
 use Translate\Controller\TranslateAppController;
 use Translate\Lib\ConvertLib;
+use Translate\Service\DomainScannerService;
 use Translate\Translator\Translator;
 
 /**
@@ -634,6 +636,133 @@ class TranslateController extends TranslateAppController {
 		ksort($names);
 
 		return $names;
+	}
+
+	/**
+	 * Scan the project (app + plugins/) for `__d('domain', ...)` calls and
+	 * report which translation domains are in use, plus whether each domain
+	 * has an app-level locale file. Suggests next steps per domain.
+	 *
+	 * Read-only; never writes anything to disk or database.
+	 *
+	 * @return void
+	 */
+	public function domains(): void {
+		$projectId = $this->Translation->currentProjectId();
+		$projectPath = null;
+		if ($projectId) {
+			$project = $this->TranslateDomains->TranslateProjects->get($projectId);
+			$projectPath = $project->path ?? null;
+		}
+		if ($projectPath && !str_starts_with($projectPath, DIRECTORY_SEPARATOR)) {
+			$projectPath = ROOT . DIRECTORY_SEPARATOR . $projectPath;
+		}
+		$projectPath ??= ROOT;
+
+		$scanner = new DomainScannerService();
+		$paths = $scanner->discoverPaths($projectPath);
+		$detected = $scanner->scan($paths);
+
+		// Determine app locale paths to check coverage against
+		$localePaths = (array)Configure::read('App.paths.locales', []);
+		if (!$localePaths) {
+			$localePaths = [ROOT . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR];
+		}
+		$defaultLocale = (string)Configure::read('App.defaultLocale', 'en_US');
+		$normalizedDefault = str_replace('-', '_', $defaultLocale);
+
+		// Discover all locales present on disk under any locale path
+		$availableLocales = [];
+		foreach ($localePaths as $lp) {
+			if (!is_dir($lp)) {
+				continue;
+			}
+			foreach ((array)scandir($lp) as $entry) {
+				if ($entry === '.' || $entry === '..') {
+					continue;
+				}
+				if (is_dir($lp . $entry)) {
+					$availableLocales[$entry] = true;
+				}
+			}
+		}
+		// Always include the default locale even if no folder exists yet
+		$availableLocales[$normalizedDefault] = true;
+		// Also include the language-only fallback (e.g. de from de_DE), since
+		// CakePHP's translator falls back to the parent locale automatically.
+		if (str_contains($normalizedDefault, '_')) {
+			$availableLocales[explode('_', $normalizedDefault)[0]] = true;
+		}
+		$availableLocales = array_keys($availableLocales);
+		sort($availableLocales);
+
+		// Per-domain coverage summary
+		$domainsReport = [];
+		foreach ($detected as $domain => $info) {
+			$coverage = [];
+			foreach ($availableLocales as $locale) {
+				$found = null;
+				// Check the locale itself, then its parent language (e.g. de_DE → de)
+				$candidates = [$locale];
+				if (str_contains($locale, '_')) {
+					$candidates[] = explode('_', $locale)[0];
+				}
+				foreach ($candidates as $loc) {
+					foreach ($localePaths as $lp) {
+						$candidate = rtrim($lp, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $loc . DIRECTORY_SEPARATOR . $domain . '.po';
+						if (is_file($candidate)) {
+							$found = $candidate;
+							break 2;
+						}
+					}
+				}
+				$coverage[$locale] = $found;
+			}
+			$potFile = null;
+			foreach ($localePaths as $lp) {
+				$candidate = rtrim($lp, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $domain . '.pot';
+				if (is_file($candidate)) {
+					$potFile = $candidate;
+					break;
+				}
+			}
+			$domainsReport[$domain] = [
+				'msgidCount' => count($info['msgids']),
+				'callCount' => $info['callCount'],
+				'fileCount' => $info['fileCount'],
+				'sampleMsgids' => array_slice(array_keys($info['msgids']), 0, 5),
+				'firstFiles' => array_slice(array_keys($this->collectFiles($info['msgids'])), 0, 3),
+				'coverage' => $coverage,
+				'potFile' => $potFile,
+				'isDefaultDomain' => $domain === 'default',
+			];
+		}
+
+		$this->set(compact(
+			'domainsReport',
+			'paths',
+			'availableLocales',
+			'localePaths',
+			'normalizedDefault',
+			'projectPath',
+		));
+	}
+
+	/**
+	 * Flatten the msgid → file → lines map into a unique-files map.
+	 *
+	 * @param array<string, array<string, array<int>>> $msgids
+	 * @return array<string, true>
+	 */
+	protected function collectFiles(array $msgids): array {
+		$files = [];
+		foreach ($msgids as $msgid => $fileLines) {
+			foreach ($fileLines as $file => $lines) {
+				$files[$file] = true;
+			}
+		}
+
+		return $files;
 	}
 
 }

--- a/src/Controller/Admin/TranslateStringsController.php
+++ b/src/Controller/Admin/TranslateStringsController.php
@@ -289,12 +289,20 @@ class TranslateStringsController extends TranslateAppController {
 		$translateLocales = $this->TranslateStrings->TranslateTerms->TranslateLocales->getExtractableAsList($projectId);
 		$poFileLanguages = $extractService->getPoFileLanguages();
 
+		// Optional preselection from query string (e.g. linked from Detected Domains analyzer).
+		$preselectDomain = (string)$this->request->getQuery('domain');
+		$preselectedPot = [];
+		$preselectedPo = [];
+
 		// Filter to only include files that actually exist
 		$potFiles = [];
 		foreach ($extractService->getPotFiles() as $potFile) {
 			if (file_exists($localePath . $potFile . '.pot')) {
 				$potFiles[$potFile] = $potFile;
 			}
+		}
+		if ($preselectDomain !== '' && isset($potFiles[$preselectDomain])) {
+			$preselectedPot[] = $preselectDomain;
 		}
 
 		$poFiles = [];
@@ -303,6 +311,9 @@ class TranslateStringsController extends TranslateAppController {
 			foreach ($extractService->getPoFiles($poFileLanguage) as $key => $poFile) {
 				if (file_exists($localePath . $poFileLanguage . DS . $poFile . '.po')) {
 					$existingFiles[$key] = $poFile;
+					if ($preselectDomain !== '' && $poFile === $preselectDomain) {
+						$preselectedPo[] = $poFileLanguage . '-' . $poFile;
+					}
 				}
 			}
 			if ($existingFiles) {
@@ -424,7 +435,7 @@ class TranslateStringsController extends TranslateAppController {
 			$this->request = $this->request->withData('sel_po', $selPo);
 		}
 
-		$this->set(compact('potFiles', 'poFiles', 'localePath'));
+		$this->set(compact('potFiles', 'poFiles', 'localePath', 'preselectedPot', 'preselectedPo', 'preselectDomain'));
 	}
 
 	/**

--- a/src/Service/DomainScannerService.php
+++ b/src/Service/DomainScannerService.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Translate\Service;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Scans PHP source for __d() and __dn() calls and reports which translation
+ * domains are in use, where, and which msgids are referenced for each.
+ *
+ * The scanner does not depend on a CakePHP application bootstrap or the
+ * translation cache — it works on raw PHP source via token_get_all().
+ */
+class DomainScannerService {
+
+	/**
+	 * Functions whose first argument is the translation domain.
+	 *
+	 * The value is the position (0-indexed) of the msgid argument relative
+	 * to the function call, after the domain.
+	 *
+	 * @var array<string, int>
+	 */
+	protected const DOMAIN_FUNCTIONS = [
+		'__d' => 1,
+		'__dn' => 1,
+		'__dx' => 2,
+		'__dxn' => 2,
+	];
+
+	/**
+	 * Default sub-directories to scan inside each project root.
+	 *
+	 * @var array<string>
+	 */
+	public const DEFAULT_SUBDIRS = ['src', 'templates', 'config'];
+
+	/**
+	 * Scan a list of root paths for translation calls and return per-domain usage.
+	 *
+	 * @param array<string> $paths Absolute paths. Subdirs (src/, templates/, config/) are scanned.
+	 * @param array<string> $subdirs Sub-directories under each path to scan. Defaults to src/templates/config.
+	 * @return array<string, array{
+	 *     msgids: array<string, array<string, array<int>>>,
+	 *     fileCount: int,
+	 *     callCount: int,
+	 * }> Map domain => {msgids => msgid => file => [lines], fileCount, callCount}
+	 */
+	public function scan(array $paths, array $subdirs = self::DEFAULT_SUBDIRS): array {
+		$result = [];
+		foreach ($paths as $root) {
+			$root = rtrim($root, DIRECTORY_SEPARATOR);
+			foreach ($subdirs as $sub) {
+				$dir = $root . DIRECTORY_SEPARATOR . $sub;
+				if (!is_dir($dir)) {
+					continue;
+				}
+				$this->scanDirectory($dir, $result);
+			}
+		}
+
+		// Compute per-domain summary stats
+		foreach ($result as $domain => &$entry) {
+			$files = [];
+			$calls = 0;
+			foreach ($entry['msgids'] as $msgid => $fileLines) {
+				foreach ($fileLines as $file => $lines) {
+					$files[$file] = true;
+					$calls += count($lines);
+				}
+			}
+			$entry['fileCount'] = count($files);
+			$entry['callCount'] = $calls;
+			ksort($entry['msgids']);
+		}
+		unset($entry);
+		ksort($result);
+
+		return $result;
+	}
+
+	/**
+	 * Discover the project root + its plugins/ folder as scan paths.
+	 *
+	 * @param string $appRoot Absolute path to the project root (typically ROOT).
+	 * @return array<string> Sorted list of directories to feed into scan().
+	 */
+	public function discoverPaths(string $appRoot): array {
+		$paths = [$appRoot];
+		$pluginsDir = rtrim($appRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'plugins';
+		if (is_dir($pluginsDir)) {
+			$entries = scandir($pluginsDir) ?: [];
+			foreach ($entries as $name) {
+				if ($name === '.' || $name === '..') {
+					continue;
+				}
+				$pluginPath = $pluginsDir . DIRECTORY_SEPARATOR . $name;
+				if (is_dir($pluginPath)) {
+					$paths[] = $pluginPath;
+				}
+			}
+		}
+
+		return $paths;
+	}
+
+	/**
+	 * @param string $dir
+	 * @param array<string, array{msgids: array<string, array<string, array<int>>>}> $result
+	 * @return void
+	 */
+	protected function scanDirectory(string $dir, array &$result): void {
+		$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS));
+		foreach ($it as $file) {
+			$path = (string)$file;
+			if (substr($path, -4) !== '.php') {
+				continue;
+			}
+			// Skip nested vendor/ and node_modules/ inside plugins
+			if (str_contains($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR)
+				|| str_contains($path, DIRECTORY_SEPARATOR . 'node_modules' . DIRECTORY_SEPARATOR)
+			) {
+				continue;
+			}
+			$this->scanFile($path, $result);
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param array<string, array{msgids: array<string, array<string, array<int>>>}> $result
+	 * @return void
+	 */
+	protected function scanFile(string $path, array &$result): void {
+		$src = (string)file_get_contents($path);
+		// Cheap pre-filter: skip files with no __d at all
+		if (!str_contains($src, '__d')) {
+			return;
+		}
+
+		$tokens = token_get_all($src);
+		// Strip whitespace/inline-html for easier walking
+		$compact = [];
+		foreach ($tokens as $t) {
+			if (is_array($t) && ($t[0] === T_WHITESPACE || $t[0] === T_INLINE_HTML)) {
+				continue;
+			}
+			$compact[] = $t;
+		}
+		$count = count($compact);
+
+		for ($i = 0; $i < $count - 1; $i++) {
+			$tok = $compact[$i];
+			if (!is_array($tok) || $tok[0] !== T_STRING) {
+				continue;
+			}
+			$name = $tok[1];
+			if (!isset(self::DOMAIN_FUNCTIONS[$name])) {
+				continue;
+			}
+			// Skip method/static calls like $foo->__d() or Foo::__d()
+			$prev = $i > 0 ? $compact[$i - 1] : null;
+			if (is_array($prev) && ($prev[0] === T_OBJECT_OPERATOR || $prev[0] === T_DOUBLE_COLON || $prev[0] === T_NULLSAFE_OBJECT_OPERATOR)) {
+				continue;
+			}
+			if ($compact[$i + 1] !== '(') {
+				continue;
+			}
+			$line = (int)$tok[2];
+			// Read first string argument (the domain)
+			$domain = $this->readStringArg($compact, $i + 2);
+			if ($domain === null) {
+				continue;
+			}
+			// Read msgid: it's the next string after a comma
+			$msgidPos = $this->advancePastArg($compact, $i + 2);
+			if ($msgidPos === null || ($compact[$msgidPos] ?? null) !== ',') {
+				$result[$domain]['msgids'][''] [$path][] = $line;
+				continue;
+			}
+			$msgid = $this->readStringArg($compact, $msgidPos + 1);
+			$key = $msgid ?? '';
+			$result[$domain]['msgids'][$key][$path][] = $line;
+		}
+	}
+
+	/**
+	 * If $tokens[$pos] is a single-string literal, return its decoded value.
+	 *
+	 * @param array<array<int|string>|string> $tokens
+	 * @param int $pos
+	 * @return string|null
+	 */
+	protected function readStringArg(array $tokens, int $pos): ?string {
+		$tok = $tokens[$pos] ?? null;
+		if (!is_array($tok)) {
+			return null;
+		}
+		$type = $tok[0];
+		$value = $tok[1];
+		if ($type === T_CONSTANT_ENCAPSED_STRING) {
+			$first = $value[0] ?? '';
+			$inner = substr($value, 1, -1);
+			if ($first === '"') {
+				return stripcslashes($inner);
+			}
+			// Single-quoted: only \' and \\ are processed
+			return strtr($inner, ['\\\'' => "'", '\\\\' => '\\']);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Advance the cursor past one balanced argument (literal, method call,
+	 * concatenation, etc.) and return the position of the comma or `)` that
+	 * follows it. Returns null if not balanced.
+	 *
+	 * @param array<array<int|string>|string> $tokens
+	 * @param int $start
+	 * @return int|null
+	 */
+	protected function advancePastArg(array $tokens, int $start): ?int {
+		$depth = 0;
+		$count = count($tokens);
+		for ($i = $start; $i < $count; $i++) {
+			$tok = $tokens[$i];
+			if ($tok === '(' || $tok === '[' || $tok === '{') {
+				$depth++;
+				continue;
+			}
+			if ($tok === ')' || $tok === ']' || $tok === '}') {
+				if ($depth === 0) {
+					return $i;
+				}
+				$depth--;
+				continue;
+			}
+			if ($depth === 0 && $tok === ',') {
+				return $i;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/Service/DomainScannerService.php
+++ b/src/Service/DomainScannerService.php
@@ -156,7 +156,7 @@ class DomainScannerService {
 				continue;
 			}
 			$name = $tok[1];
-			if (!isset(self::DOMAIN_FUNCTIONS[$name])) {
+			if (!isset(static::DOMAIN_FUNCTIONS[$name])) {
 				continue;
 			}
 			// Skip method/static calls like $foo->__d() or Foo::__d()
@@ -176,7 +176,8 @@ class DomainScannerService {
 			// Read msgid: it's the next string after a comma
 			$msgidPos = $this->advancePastArg($compact, $i + 2);
 			if ($msgidPos === null || ($compact[$msgidPos] ?? null) !== ',') {
-				$result[$domain]['msgids'][''] [$path][] = $line;
+				$result[$domain]['msgids'][''][$path][] = $line;
+
 				continue;
 			}
 			$msgid = $this->readStringArg($compact, $msgidPos + 1);
@@ -188,7 +189,7 @@ class DomainScannerService {
 	/**
 	 * If $tokens[$pos] is a single-string literal, return its decoded value.
 	 *
-	 * @param array<array<int|string>|string> $tokens
+	 * @param array<array{0: int, 1: string, 2: int}|string> $tokens
 	 * @param int $pos
 	 * @return string|null
 	 */
@@ -198,13 +199,14 @@ class DomainScannerService {
 			return null;
 		}
 		$type = $tok[0];
-		$value = $tok[1];
+		$value = (string)$tok[1];
 		if ($type === T_CONSTANT_ENCAPSED_STRING) {
 			$first = $value[0] ?? '';
 			$inner = substr($value, 1, -1);
 			if ($first === '"') {
 				return stripcslashes($inner);
 			}
+
 			// Single-quoted: only \' and \\ are processed
 			return strtr($inner, ['\\\'' => "'", '\\\\' => '\\']);
 		}
@@ -217,7 +219,7 @@ class DomainScannerService {
 	 * concatenation, etc.) and return the position of the comma or `)` that
 	 * follows it. Returns null if not balanced.
 	 *
-	 * @param array<array<int|string>|string> $tokens
+	 * @param array<array{0: int, 1: string, 2: int}|string> $tokens
 	 * @param int $start
 	 * @return int|null
 	 */
@@ -228,6 +230,7 @@ class DomainScannerService {
 			$tok = $tokens[$i];
 			if ($tok === '(' || $tok === '[' || $tok === '{') {
 				$depth++;
+
 				continue;
 			}
 			if ($tok === ')' || $tok === ']' || $tok === '}') {
@@ -235,6 +238,7 @@ class DomainScannerService {
 					return $i;
 				}
 				$depth--;
+
 				continue;
 			}
 			if ($depth === 0 && $tok === ',') {

--- a/templates/Admin/Translate/domains.php
+++ b/templates/Admin/Translate/domains.php
@@ -10,6 +10,9 @@
  *     coverage: array<string, string|null>,
  *     potFile: string|null,
  *     isDefaultDomain: bool,
+ *     hasImportedStrings: bool,
+ *     importedStringCount: int,
+ *     stage: string,
  * }> $domainsReport
  * @var array<string> $paths
  * @var array<string> $availableLocales
@@ -145,23 +148,68 @@ $shortenPath = function (string $abs) use ($projectPath): string {
 											</td>
 										<?php } ?>
 										<td>
-											<?php
-											$missingDefault = empty($info['coverage'][$normalizedDefault]) && !$info['isDefaultDomain'];
-											if ($info['isDefaultDomain']) {
-												echo '<span class="text-muted">' . __d('translate', 'Use the regular i18n extract for the default domain.') . '</span>';
-											} elseif ($missingDefault) {
-												echo '<span class="text-warning">' . __d('translate', 'Create an app-level {0}.po — strings would otherwise silently fall back to the default domain.', $domain) . '</span>';
-											} else {
-												echo '<span class="text-success">' . __d('translate', 'Covered.') . '</span>';
-											}
-											?>
-											<div class="mt-1">
-												<?= $this->Html->link(
-													'<i class="fas fa-flask"></i> ' . __d('translate', 'Run extract'),
-													['controller' => 'TranslateStrings', 'action' => 'extract', '?' => ['domain' => $domain]],
-													['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
-												) ?>
-											</div>
+											<?php switch ($info['stage']) {
+												case 'default': ?>
+													<span class="text-muted small"><?= __d('translate', 'Use the regular i18n extract for the default domain.') ?></span>
+													<?php break;
+												case 'extract': ?>
+													<span class="badge bg-secondary"><?= __d('translate', 'Stage 1: Extract') ?></span>
+													<div class="small text-warning mt-1">
+														<?= __d('translate', 'No POT yet — run i18n extract to generate it.') ?>
+													</div>
+													<div class="mt-1">
+														<?= $this->Html->link(
+															'<i class="fas fa-flask"></i> ' . __d('translate', 'Run i18n Extract'),
+															['controller' => 'TranslateStrings', 'action' => 'runExtract'],
+															['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
+														) ?>
+													</div>
+													<?php break;
+												case 'import': ?>
+													<span class="badge bg-info"><?= __d('translate', 'Stage 2: Import') ?></span>
+													<div class="small text-warning mt-1">
+														<?= __d('translate', 'POT exists but no strings imported — load it into the DB.') ?>
+													</div>
+													<div class="mt-1">
+														<?= $this->Html->link(
+															'<i class="fas fa-file-import"></i> ' . __d('translate', 'Import {0}.pot', $domain),
+															['controller' => 'TranslateStrings', 'action' => 'extract', '?' => ['domain' => $domain]],
+															['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-info'],
+														) ?>
+													</div>
+													<?php break;
+												case 'dump': ?>
+													<span class="badge bg-warning text-dark"><?= __d('translate', 'Stage 3: Dump') ?></span>
+													<div class="small text-warning mt-1">
+														<?= __d('translate', '{0} string(s) in DB but no app-level {1}.po — dump to filesystem so the app can load it.', $info['importedStringCount'], $domain) ?>
+													</div>
+													<div class="mt-1">
+														<?= $this->Html->link(
+															'<i class="fas fa-file-export"></i> ' . __d('translate', 'Dump translations'),
+															['controller' => 'TranslateStrings', 'action' => 'dump'],
+															['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-warning'],
+														) ?>
+													</div>
+													<?php break;
+												case 'covered':
+												default: ?>
+													<span class="badge bg-success"><?= __d('translate', 'Covered') ?></span>
+													<div class="small text-muted mt-1">
+														<?php if ($info['hasImportedStrings']) { ?>
+															<?= __d('translate', '{0} string(s) in DB, default-locale .po present.', $info['importedStringCount']) ?>
+														<?php } else { ?>
+															<?= __d('translate', 'Default-locale .po present (managed outside the DB workflow).') ?>
+														<?php } ?>
+													</div>
+													<div class="mt-1">
+														<?= $this->Html->link(
+															'<i class="fas fa-flask"></i> ' . __d('translate', 'Re-extract'),
+															['controller' => 'TranslateStrings', 'action' => 'runExtract'],
+															['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary'],
+														) ?>
+													</div>
+													<?php break;
+											} ?>
 										</td>
 									</tr>
 									<tr class="table-light">

--- a/templates/Admin/Translate/domains.php
+++ b/templates/Admin/Translate/domains.php
@@ -21,13 +21,27 @@
  * @var string $projectPath
  */
 
+/**
+ * Shorten an absolute path to `APP/...` (relative to the project root).
+ * Adds a trailing slash for directory paths.
+ */
 $shortenPath = function (string $abs) use ($projectPath): string {
-	$root = rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-	if (str_starts_with($abs, $root)) {
-		return './' . substr($abs, strlen($root));
+	$root = rtrim($projectPath, DIRECTORY_SEPARATOR);
+	$normalizedAbs = rtrim($abs, DIRECTORY_SEPARATOR);
+	if ($normalizedAbs === $root) {
+		return 'APP/';
+	}
+	if (str_starts_with($normalizedAbs, $root . DIRECTORY_SEPARATOR)) {
+		$relative = substr($normalizedAbs, strlen($root) + 1);
+		$shortened = 'APP/' . $relative;
+	} else {
+		$shortened = $normalizedAbs;
+	}
+	if (is_dir($abs)) {
+		$shortened .= '/';
 	}
 
-	return $abs;
+	return $shortened;
 };
 
 ?>
@@ -63,7 +77,7 @@ $shortenPath = function (string $abs) use ($projectPath): string {
 			</div>
 			<ul class="list-group list-group-flush small">
 				<?php foreach ($paths as $p) { ?>
-					<li class="list-group-item"><?= h($p) ?></li>
+					<li class="list-group-item" title="<?= h($p) ?>"><code><?= h($shortenPath($p)) ?></code></li>
 				<?php } ?>
 			</ul>
 		</div>
@@ -74,7 +88,7 @@ $shortenPath = function (string $abs) use ($projectPath): string {
 			</div>
 			<ul class="list-group list-group-flush small">
 				<?php foreach ($localePaths as $lp) { ?>
-					<li class="list-group-item"><?= h($lp) ?></li>
+					<li class="list-group-item" title="<?= h($lp) ?>"><code><?= h($shortenPath($lp)) ?></code></li>
 				<?php } ?>
 			</ul>
 		</div>

--- a/templates/Admin/Translate/domains.php
+++ b/templates/Admin/Translate/domains.php
@@ -29,11 +29,10 @@ $shortenPath = function (string $abs) use ($projectPath): string {
 	$root = rtrim($projectPath, DIRECTORY_SEPARATOR);
 	$normalizedAbs = rtrim($abs, DIRECTORY_SEPARATOR);
 	if ($normalizedAbs === $root) {
-		return 'APP/';
+		return 'APP';
 	}
 	if (str_starts_with($normalizedAbs, $root . DIRECTORY_SEPARATOR)) {
-		$relative = substr($normalizedAbs, strlen($root) + 1);
-		$shortened = 'APP/' . $relative;
+		$shortened = 'APP/' . substr($normalizedAbs, strlen($root) + 1);
 	} else {
 		$shortened = $normalizedAbs;
 	}

--- a/templates/Admin/Translate/domains.php
+++ b/templates/Admin/Translate/domains.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<string, array{
+ *     msgidCount: int,
+ *     callCount: int,
+ *     fileCount: int,
+ *     sampleMsgids: array<string>,
+ *     firstFiles: array<string>,
+ *     coverage: array<string, string|null>,
+ *     potFile: string|null,
+ *     isDefaultDomain: bool,
+ * }> $domainsReport
+ * @var array<string> $paths
+ * @var array<string> $availableLocales
+ * @var array<string> $localePaths
+ * @var string $normalizedDefault
+ * @var string $projectPath
+ */
+
+$shortenPath = function (string $abs) use ($projectPath): string {
+	$root = rtrim($projectPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+	if (str_starts_with($abs, $root)) {
+		return './' . substr($abs, strlen($root));
+	}
+
+	return $abs;
+};
+
+?>
+<div class="row">
+	<!-- Sidebar -->
+	<nav class="col-lg-3 col-md-4 mb-4">
+		<div class="card">
+			<div class="card-header">
+				<i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?>
+			</div>
+			<div class="list-group list-group-flush">
+				<?= $this->Html->link(
+					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
+					['controller' => 'Translate', 'action' => 'index'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
+				) ?>
+				<?= $this->Html->link(
+					'<i class="fas fa-folder"></i> ' . __d('translate', 'Translate Domains'),
+					['controller' => 'TranslateDomains', 'action' => 'index'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
+				) ?>
+				<?= $this->Html->link(
+					'<i class="fas fa-flask"></i> ' . __d('translate', 'Run i18n Extract'),
+					['controller' => 'TranslateStrings', 'action' => 'extract'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
+				) ?>
+			</div>
+		</div>
+
+		<div class="card mt-3">
+			<div class="card-header">
+				<i class="fas fa-folder-open"></i> <?= __d('translate', 'Scanned Paths') ?>
+			</div>
+			<ul class="list-group list-group-flush small">
+				<?php foreach ($paths as $p) { ?>
+					<li class="list-group-item"><?= h($p) ?></li>
+				<?php } ?>
+			</ul>
+		</div>
+
+		<div class="card mt-3">
+			<div class="card-header">
+				<i class="fas fa-info-circle"></i> <?= __d('translate', 'Locale Paths') ?>
+			</div>
+			<ul class="list-group list-group-flush small">
+				<?php foreach ($localePaths as $lp) { ?>
+					<li class="list-group-item"><?= h($lp) ?></li>
+				<?php } ?>
+			</ul>
+		</div>
+	</nav>
+
+	<!-- Main Content -->
+	<div class="col-lg-9 col-md-8">
+		<div class="card">
+			<div class="card-header d-flex align-items-center justify-content-between">
+				<h2 class="mb-0">
+					<i class="fas fa-search"></i>
+					<?= __d('translate', 'Detected Domains') ?>
+				</h2>
+				<span class="badge bg-secondary">
+					<?= count($domainsReport) ?> <?= __d('translate', 'domains') ?>
+				</span>
+			</div>
+			<div class="card-body">
+				<p class="text-muted">
+					<?= __d('translate', 'Scanned the project source for `__d(domain, ...)` calls. Each row shows whether an app-level PO file exists for that domain in each available locale.') ?>
+				</p>
+
+				<?php if (!$domainsReport) { ?>
+					<div class="alert alert-info">
+						<?= __d('translate', 'No `__d()` calls found in the scanned paths.') ?>
+					</div>
+				<?php } else { ?>
+					<div class="table-responsive">
+						<table class="table table-hover align-middle">
+							<thead>
+								<tr>
+									<th><?= __d('translate', 'Domain') ?></th>
+									<th class="text-end"><?= __d('translate', 'msgids') ?></th>
+									<th class="text-end"><?= __d('translate', 'Calls') ?></th>
+									<th class="text-end"><?= __d('translate', 'Files') ?></th>
+									<th><?= __d('translate', 'POT') ?></th>
+									<?php foreach ($availableLocales as $locale) { ?>
+										<th class="text-center" style="font-family:monospace"><?= h($locale) ?></th>
+									<?php } ?>
+									<th><?= __d('translate', 'Suggestion') ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ($domainsReport as $domain => $info) { ?>
+									<tr>
+										<td>
+											<strong><?= h($domain) ?></strong>
+											<?php if ($info['isDefaultDomain']) { ?>
+												<span class="badge bg-secondary ms-1" title="<?= __d('translate', 'CakePHP default domain — typically translated via the app default.po') ?>">default</span>
+											<?php } ?>
+										</td>
+										<td class="text-end"><?= $info['msgidCount'] ?></td>
+										<td class="text-end"><?= $info['callCount'] ?></td>
+										<td class="text-end"><?= $info['fileCount'] ?></td>
+										<td>
+											<?php if ($info['potFile']) { ?>
+												<i class="fas fa-check text-success" title="<?= h($info['potFile']) ?>"></i>
+											<?php } else { ?>
+												<i class="fas fa-times text-muted" title="<?= __d('translate', 'No app-level POT file') ?>"></i>
+											<?php } ?>
+										</td>
+										<?php foreach ($availableLocales as $locale) {
+											$po = $info['coverage'][$locale] ?? null;
+										?>
+											<td class="text-center">
+												<?php if ($po) { ?>
+													<i class="fas fa-check text-success" title="<?= h($po) ?>"></i>
+												<?php } else { ?>
+													<i class="fas fa-times text-danger" title="<?= __d('translate', 'Missing app-level {0}.po — falls back to default domain', $domain) ?>"></i>
+												<?php } ?>
+											</td>
+										<?php } ?>
+										<td>
+											<?php
+											$missingDefault = empty($info['coverage'][$normalizedDefault]) && !$info['isDefaultDomain'];
+											if ($info['isDefaultDomain']) {
+												echo '<span class="text-muted">' . __d('translate', 'Use the regular i18n extract for the default domain.') . '</span>';
+											} elseif ($missingDefault) {
+												echo '<span class="text-warning">' . __d('translate', 'Create an app-level {0}.po — strings would otherwise silently fall back to the default domain.', $domain) . '</span>';
+											} else {
+												echo '<span class="text-success">' . __d('translate', 'Covered.') . '</span>';
+											}
+											?>
+											<div class="mt-1">
+												<?= $this->Html->link(
+													'<i class="fas fa-flask"></i> ' . __d('translate', 'Run extract'),
+													['controller' => 'TranslateStrings', 'action' => 'extract', '?' => ['domain' => $domain]],
+													['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
+												) ?>
+											</div>
+										</td>
+									</tr>
+									<tr class="table-light">
+										<td colspan="<?= 6 + count($availableLocales) ?>" class="small text-muted">
+											<?php if ($info['firstFiles']) { ?>
+												<strong><?= __d('translate', 'Used in') ?>:</strong>
+												<?php foreach ($info['firstFiles'] as $i => $f) { ?>
+													<?= $i > 0 ? ', ' : '' ?><code><?= h($shortenPath($f)) ?></code>
+												<?php } ?>
+												<?php if ($info['fileCount'] > count($info['firstFiles'])) { ?>
+													<em>(+<?= $info['fileCount'] - count($info['firstFiles']) ?> <?= __d('translate', 'more') ?>)</em>
+												<?php } ?>
+												<br>
+											<?php } ?>
+											<?php if ($info['sampleMsgids']) { ?>
+												<strong><?= __d('translate', 'Sample msgids') ?>:</strong>
+												<?php foreach ($info['sampleMsgids'] as $i => $m) { ?>
+													<?= $i > 0 ? ' · ' : '' ?><code><?= h(mb_strimwidth((string)$m, 0, 60, '…')) ?></code>
+												<?php } ?>
+											<?php } ?>
+										</td>
+									</tr>
+								<?php } ?>
+							</tbody>
+						</table>
+					</div>
+				<?php } ?>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/Admin/Translate/index.php
+++ b/templates/Admin/Translate/index.php
@@ -910,6 +910,11 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
+							'<i class="fas fa-search"></i> ' . __d('translate', 'Detected Domains'),
+							['action' => 'domains'],
+							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+						) ?>
+						<?= $this->Html->link(
 							'<i class="fas fa-info-circle"></i> ' . __d('translate', 'Best Practices'),
 							['action' => 'bestPractice'],
 							['escape' => false, 'class' => 'list-group-item list-group-item-action'],

--- a/templates/Admin/TranslateStrings/extract.php
+++ b/templates/Admin/TranslateStrings/extract.php
@@ -4,8 +4,14 @@
  * @var mixed $poFiles
  * @var mixed $potFiles
  * @var string $localePath
+ * @var array<string> $preselectedPot
+ * @var array<string> $preselectedPo
+ * @var string $preselectDomain
  */
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+$preselectedPot = $preselectedPot ?? [];
+$preselectedPo = $preselectedPo ?? [];
+$preselectDomain = $preselectDomain ?? '';
 ?>
 <div class="row">
 	<aside class="col-md-3 col-sm-4 col-12">
@@ -32,6 +38,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<strong><?= __d('translate', 'Locale Path:') ?></strong>
 					<code><?= h($localePath) ?></code>
 				</div>
+				<?php if ($preselectDomain !== '' && ($preselectedPot || $preselectedPo)) { ?>
+					<div class="alert alert-primary mb-3">
+						<i class="fas fa-info-circle"></i>
+						<?= __d('translate', 'Pre-selected the {0} domain (linked from Detected Domains analyzer).', '<code>' . h($preselectDomain) . '</code>') ?>
+					</div>
+				<?php } ?>
 				<?= $this->Form->create(null) ?>
 					<fieldset>
 						<legend><?= __d('translate', 'From POT File') ?></legend>
@@ -44,6 +56,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 								'multiple' => 'checkbox',
 								'label' => __d('translate', 'Selection'),
 								'options' => $potFiles,
+								'default' => $preselectedPot,
 							]) ?>
 						</div>
 					</fieldset>
@@ -59,6 +72,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 								'multiple' => 'checkbox',
 								'label' => __d('translate', 'Selection'),
 								'options' => $poFiles,
+								'default' => $preselectedPo,
 							]) ?>
 						</div>
 					</fieldset>


### PR DESCRIPTION
Adds a new admin action `TranslateController::domains()` that scans the project source for translation calls and reports which `__d()` domains are in use, where, and whether each has an app-level PO file for each available locale.

## What it does

Token-walks every PHP file under the project root + `plugins/` (skipping nested `vendor/` and `node_modules/`) looking for:

- `__d('domain', 'msgid', …)`
- `__dn('domain', 'singular', 'plural', …)`
- `__dx('domain', 'context', 'msgid', …)`
- `__dxn('domain', 'context', 'singular', 'plural', …)`

It skips method/static calls (`$x->__d()`, `Foo::__d()`) and only counts free-function invocations. For each detected domain the dashboard shows:

- Unique msgid count, total call sites, file count
- Whether an app-level `<domain>.pot` exists
- Per-locale coverage (`✓` / `✗` for each locale folder under `App.paths.locales`, with parent-language fallback so `de/` covers `de_DE`)
- A suggestion column — flags non-default domains missing the default-locale PO as silent-fallback risk

## Why

The existing PO Analyzer (`PoAnalyzerService`) is single-file scoped — there was no project-level view of "what domains do I actually use, and is each one covered?" That gap was easy to walk into: a missing `de/queue.po` silently lets `__d('queue', 'Job')` fall through to a `default.po` translation of `Job` from a totally unrelated context (e.g. a member-profile field), with no error or warning anywhere.

## Reusability

The scanning logic lives in `Translate\Service\DomainScannerService` so it can be reused from a CLI command or CI check later (and it has no dependency on the request lifecycle).

## Out of scope (planned follow-ups)

- Stray `__()` in plugin sources (best-practice violation, default-domain leak)
- Test-fixture PO files in `resources/locales/` (cf. #49)
- Automatically creating a skeleton PO from the scanned msgids
- A `bin/cake translate doctor` CLI variant