### PR TITLE
Use escapeTitle (not escape=>false) for HTML-titled links/buttons; scope label escape opt-out

### DIFF
--- a/templates/Admin/I18nEntries/edit.php
+++ b/templates/Admin/I18nEntries/edit.php
@@ -20,7 +20,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			<?= $this->Html->link(__d('translate', 'I18n Entries'), ['action' => 'index']) ?>
 		</li>
 		<li class="breadcrumb-item">
-			<?= $this->Html->link(h($baseTableName), ['action' => 'entries', $tableName]) ?>
+			<?= $this->Html->link($baseTableName, ['action' => 'entries', $tableName]) ?>
 		</li>
 		<li class="breadcrumb-item active"><?= __d('translate', 'Edit') ?> #<?= h($entry->id) ?></li>
 	</ol>

--- a/templates/Admin/I18nEntries/edit.php
+++ b/templates/Admin/I18nEntries/edit.php
@@ -125,7 +125,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 				<?= $this->Html->link(
 					'<i class="fas fa-times"></i> ' . __d('translate', 'Cancel'),
 					['action' => 'entries', $tableName],
-					['class' => 'btn btn-outline-secondary', 'escape' => false],
+					['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 				) ?>
 			</div>
 			<?= $this->Form->end() ?>

--- a/templates/Admin/I18nEntries/entries.php
+++ b/templates/Admin/I18nEntries/entries.php
@@ -229,12 +229,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 										<?= $this->Html->link(
 											'<i class="fas fa-eye"></i>',
 											['action' => 'view', $tableName, $entry->id],
-											['class' => 'btn btn-sm btn-outline-primary', 'escape' => false, 'title' => __d('translate', 'View')],
+											['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false, 'title' => __d('translate', 'View')],
 										) ?>
 										<?= $this->Html->link(
 											'<i class="fas fa-edit"></i>',
 											['action' => 'edit', $tableName, $entry->id],
-											['class' => 'btn btn-sm btn-outline-secondary', 'escape' => false, 'title' => __d('translate', 'Edit')],
+											['class' => 'btn btn-sm btn-outline-secondary', 'escapeTitle' => false, 'title' => __d('translate', 'Edit')],
 										) ?>
 										<?= $this->Form->postButton(
 											'<i class="fas fa-trash"></i>',

--- a/templates/Admin/I18nEntries/entries_base.php
+++ b/templates/Admin/I18nEntries/entries_base.php
@@ -183,7 +183,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 												echo $this->Html->link(
 													'<i class="fas fa-edit"></i>',
 													['action' => 'editTranslation', $tableName, $record->id, $locale],
-													['class' => 'btn btn-sm btn-outline-secondary', 'escape' => false, 'title' => __d('translate', 'Edit {0}', $locale)],
+													['class' => 'btn btn-sm btn-outline-secondary', 'escapeTitle' => false, 'title' => __d('translate', 'Edit {0}', $locale)],
 												);
 											} else {
 												// No translation exists
@@ -192,7 +192,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 												echo $this->Html->link(
 													'<i class="fas fa-plus"></i>',
 													['action' => 'addTranslation', $tableName, $record->id, $locale],
-													['class' => 'btn btn-sm btn-outline-success', 'escape' => false, 'title' => __d('translate', 'Add {0}', $locale)],
+													['class' => 'btn btn-sm btn-outline-success', 'escapeTitle' => false, 'title' => __d('translate', 'Add {0}', $locale)],
 												);
 											}
 											?>
@@ -202,7 +202,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 										<?= $this->Html->link(
 											'<i class="fas fa-eye"></i>',
 											['action' => 'viewRecord', $tableName, $record->id],
-											['class' => 'btn btn-sm btn-outline-primary', 'escape' => false, 'title' => __d('translate', 'View All')],
+											['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false, 'title' => __d('translate', 'View All')],
 										) ?>
 									</td>
 								</tr>

--- a/templates/Admin/I18nEntries/index.php
+++ b/templates/Admin/I18nEntries/index.php
@@ -123,7 +123,7 @@
 						<?= $this->Html->link(
 							'<i class="fas fa-list"></i> ' . __d('translate', 'View Entries'),
 							['action' => 'entries', $tableName],
-							['class' => 'btn btn-primary btn-sm', 'escape' => false],
+							['class' => 'btn btn-primary btn-sm', 'escapeTitle' => false],
 						) ?>
 						<?php if ($info['base_exists'] && $info['row_count'] < $info['base_count']) { ?>
 							<?= $this->Form->postButton(
@@ -143,7 +143,7 @@
 						<?= $this->Html->link(
 							'<i class="fas fa-cog"></i>',
 							['controller' => 'TranslateBehavior', 'action' => 'view', $tableName],
-							['class' => 'btn btn-outline-secondary btn-sm', 'escape' => false, 'title' => __d('translate', 'Table Details')],
+							['class' => 'btn btn-outline-secondary btn-sm', 'escapeTitle' => false, 'title' => __d('translate', 'Table Details')],
 						) ?>
 					</div>
 				</div>

--- a/templates/Admin/I18nEntries/translation_form.php
+++ b/templates/Admin/I18nEntries/translation_form.php
@@ -19,7 +19,7 @@ $isNew = $translation->isNew();
 			<?= $this->Html->link(__d('translate', 'I18n Entries'), ['action' => 'index']) ?>
 		</li>
 		<li class="breadcrumb-item">
-			<?= $this->Html->link(h($baseTableName), ['action' => 'entries', $tableName]) ?>
+			<?= $this->Html->link($baseTableName, ['action' => 'entries', $tableName]) ?>
 		</li>
 		<li class="breadcrumb-item">
 			<?= $this->Html->link(

--- a/templates/Admin/I18nEntries/view.php
+++ b/templates/Admin/I18nEntries/view.php
@@ -18,7 +18,7 @@
 			<?= $this->Html->link(__d('translate', 'I18n Entries'), ['action' => 'index']) ?>
 		</li>
 		<li class="breadcrumb-item">
-			<?= $this->Html->link(h($baseTableName), ['action' => 'entries', $tableName]) ?>
+			<?= $this->Html->link($baseTableName, ['action' => 'entries', $tableName]) ?>
 		</li>
 		<li class="breadcrumb-item active">#<?= h($entry->id) ?></li>
 	</ol>

--- a/templates/Admin/I18nEntries/view.php
+++ b/templates/Admin/I18nEntries/view.php
@@ -92,12 +92,12 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit'),
 					['action' => 'edit', $tableName, $entry->id],
-					['class' => 'btn btn-primary', 'escape' => false],
+					['class' => 'btn btn-primary', 'escapeTitle' => false],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-arrow-left"></i> ' . __d('translate', 'Back'),
 					['action' => 'entries', $tableName],
-					['class' => 'btn btn-outline-secondary', 'escape' => false],
+					['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/I18nEntries/view_record.php
+++ b/templates/Admin/I18nEntries/view_record.php
@@ -167,13 +167,13 @@
 										<?= $this->Html->link(
 											'<i class="fas fa-edit"></i>',
 											['action' => 'editTranslation', $tableName, $baseRecord->id, $locale],
-											['class' => 'btn btn-sm btn-outline-primary', 'escape' => false, 'title' => __d('translate', 'Edit')],
+											['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false, 'title' => __d('translate', 'Edit')],
 										) ?>
 									<?php } else { ?>
 										<?= $this->Html->link(
 											'<i class="fas fa-plus"></i>',
 											['action' => 'addTranslation', $tableName, $baseRecord->id, $locale],
-											['class' => 'btn btn-sm btn-success', 'escape' => false, 'title' => __d('translate', 'Add')],
+											['class' => 'btn btn-sm btn-success', 'escapeTitle' => false, 'title' => __d('translate', 'Add')],
 										) ?>
 									<?php } ?>
 									<?php if (!$isFullyTranslated) { ?>
@@ -206,7 +206,7 @@
 		<?= $this->Html->link(
 			'<i class="fas fa-arrow-left"></i> ' . __d('translate', 'Back to List'),
 			['action' => 'entries', $tableName],
-			['class' => 'btn btn-secondary', 'escape' => false],
+			['class' => 'btn btn-secondary', 'escapeTitle' => false],
 		) ?>
 	</div>
 </div>

--- a/templates/Admin/I18nEntries/view_record.php
+++ b/templates/Admin/I18nEntries/view_record.php
@@ -18,7 +18,7 @@
 			<?= $this->Html->link(__d('translate', 'I18n Entries'), ['action' => 'index']) ?>
 		</li>
 		<li class="breadcrumb-item">
-			<?= $this->Html->link(h($baseTableName), ['action' => 'entries', $tableName]) ?>
+			<?= $this->Html->link($baseTableName, ['action' => 'entries', $tableName]) ?>
 		</li>
 		<li class="breadcrumb-item active">
 			<?= __d('translate', 'Record #{0}', $baseRecord->id) ?>

--- a/templates/Admin/Translate/best_practice.php
+++ b/templates/Admin/Translate/best_practice.php
@@ -11,7 +11,7 @@
 				<h3 class="card-title"><i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?></h3>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escape' => false, 'class' => 'list-group-item list-group-item-action']) ?>
+				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action']) ?>
 			</div>
 		</div>
 	</aside>

--- a/templates/Admin/Translate/convert.php
+++ b/templates/Admin/Translate/convert.php
@@ -13,7 +13,7 @@
 				<h3 class="card-title"><i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?></h3>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escape' => false, 'class' => 'list-group-item list-group-item-action']) ?>
+				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action']) ?>
 			</div>
 		</div>
 	</aside>

--- a/templates/Admin/Translate/index.php
+++ b/templates/Admin/Translate/index.php
@@ -33,17 +33,17 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-edit"></i>',
 									['controller' => 'TranslateProjects', 'action' => 'edit', $currentProject->id],
-									['escape' => false, 'class' => 'btn btn-outline-primary btn-sm', 'title' => __d('translate', 'Edit Project')],
+									['escapeTitle' => false, 'class' => 'btn btn-outline-primary btn-sm', 'title' => __d('translate', 'Edit Project')],
 								) ?>
 								<?= $this->Html->link(
 									'<i class="fas fa-list"></i>',
 									['controller' => 'TranslateProjects', 'action' => 'index'],
-									['escape' => false, 'class' => 'btn btn-outline-secondary btn-sm', 'title' => __d('translate', 'All Projects')],
+									['escapeTitle' => false, 'class' => 'btn btn-outline-secondary btn-sm', 'title' => __d('translate', 'All Projects')],
 								) ?>
 								<?= $this->Html->link(
 									'<i class="fas fa-language"></i>',
 									['controller' => 'TranslateStrings', 'action' => 'translate'],
-									['escape' => false, 'class' => 'btn btn-success btn-sm', 'title' => __d('translate', 'Start Translating')],
+									['escapeTitle' => false, 'class' => 'btn btn-success btn-sm', 'title' => __d('translate', 'Start Translating')],
 								) ?>
 							</div>
 						<?php } else { ?>
@@ -51,7 +51,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 							<?= $this->Html->link(
 								'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'Create'),
 								['controller' => 'TranslateProjects', 'action' => 'add'],
-								['escape' => false, 'class' => 'btn btn-success btn-sm ms-2'],
+								['escapeTitle' => false, 'class' => 'btn btn-success btn-sm ms-2'],
 							) ?>
 						<?php } ?>
 					</div>
@@ -126,7 +126,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 				<?= $this->Html->link(
 					'<i class="fas fa-tasks"></i> ' . __d('translate', 'Batch Confirm'),
 					['controller' => 'TranslateTerms', 'action' => 'pending'],
-					['escape' => false, 'class' => 'btn btn-sm btn-dark'],
+					['escapeTitle' => false, 'class' => 'btn btn-sm btn-dark'],
 				) ?>
 			</div>
 			<div class="card-body p-2">
@@ -212,7 +212,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-edit"></i>',
 									['controller' => 'TranslateStrings', 'action' => 'translate', $string->id],
-									['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'Translate')],
+									['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'Translate')],
 								) ?>
 							</div>
 						</div>
@@ -329,7 +329,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-edit"></i>',
 									['controller' => 'TranslateTerms', 'action' => 'edit', $term->id],
-									['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'Edit')],
+									['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'Edit')],
 								) ?>
 							</div>
 						</div>
@@ -513,7 +513,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-language"></i>',
 									['controller' => 'TranslateStrings', 'action' => 'translate', $string->id],
-									['escape' => false, 'class' => 'btn btn-sm btn-success', 'title' => __d('translate', 'Translate')],
+									['escapeTitle' => false, 'class' => 'btn btn-sm btn-success', 'title' => __d('translate', 'Translate')],
 								) ?>
 							</div>
 						</div>
@@ -623,7 +623,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										<?= $this->Html->link(
 											'<i class="fas fa-external-link-alt"></i> ' . __d('translate', 'View in AuditStash'),
 											['plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'view', $log->id],
-											['escape' => false, 'class' => 'btn btn-sm btn-outline-primary'],
+											['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
 										) ?>
 									</td>
 								</tr>
@@ -791,7 +791,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-question-circle"></i>',
 									'https://github.com/lorenzo/audit-stash',
-									['escape' => false, 'target' => '_blank', 'class' => 'text-muted', 'title' => __d('translate', 'AuditStash Plugin')],
+									['escapeTitle' => false, 'target' => '_blank', 'class' => 'text-muted', 'title' => __d('translate', 'AuditStash Plugin')],
 								) ?>
 							</td>
 							<td class="text-end">
@@ -820,7 +820,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 								<?= $this->Html->link(
 									'<i class="fas fa-question-circle"></i>',
 									'https://github.com/FriendsOfCake/search',
-									['escape' => false, 'target' => '_blank', 'class' => 'text-muted', 'title' => __d('translate', 'FriendsOfCake/Search Plugin')],
+									['escapeTitle' => false, 'target' => '_blank', 'class' => 'text-muted', 'title' => __d('translate', 'FriendsOfCake/Search Plugin')],
 								) ?>
 							</td>
 							<td class="text-end">
@@ -882,43 +882,43 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 						<?= $this->Html->link(
 							'<i class="fas fa-chart-bar"></i> ' . __d('translate', 'Detailed Statistics'),
 							['action' => 'stats'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-file-import"></i> ' . __d('translate', 'Import from PO/POT files'),
 							['controller' => 'TranslateStrings', 'action' => 'extract'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-file-export"></i> ' . __d('translate', 'Export to PO files'),
 							['controller' => 'TranslateStrings', 'action' => 'dump'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-folder-open"></i> ' . __d('translate', 'Import locales from filesystem'),
 							['controller' => 'TranslateLocales', 'action' => 'fromLocale'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-language"></i> ' . __d('translate', 'TranslateBehavior & Shadow Tables'),
 							['controller' => 'TranslateBehavior', 'action' => 'index'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-unlink"></i> ' . __d('translate', 'Orphaned Strings'),
 							['controller' => 'TranslateStrings', 'action' => 'orphaned'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-info-circle"></i> ' . __d('translate', 'Best Practices'),
 							['action' => 'bestPractice'],
-							['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+							['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 						) ?>
 						<?php if (Configure::read('debug')) { ?>
 							<?= $this->Html->link(
 								'<i class="fas fa-exclamation-triangle text-danger"></i> ' . __d('translate', 'Reset Project Data'),
 								['controller' => 'Translate', 'action' => 'reset'],
-								['escape' => false, 'class' => 'list-group-item list-group-item-action list-group-item-danger'],
+								['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action list-group-item-danger'],
 							) ?>
 						<?php } ?>
 					</div>

--- a/templates/Admin/Translate/reset.php
+++ b/templates/Admin/Translate/reset.php
@@ -12,7 +12,7 @@
 				<h3 class="card-title"><i class="fas fa-bars"></i> <?= __d('translate', 'Actions') ?></h3>
 			</div>
 			<div class="list-group list-group-flush">
-				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escape' => false, 'class' => 'list-group-item list-group-item-action']) ?>
+				<?= $this->Html->link('<i class="fas fa-tachometer-alt"></i> ' . __d('translate', 'Overview'), ['action' => 'index'], ['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action']) ?>
 			</div>
 		</div>
 	</aside>

--- a/templates/Admin/TranslateApiTranslations/add.php
+++ b/templates/Admin/TranslateApiTranslations/add.php
@@ -13,7 +13,7 @@
 			<div class="card-body p-0">
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 				</ul>
 			</div>

--- a/templates/Admin/TranslateApiTranslations/edit.php
+++ b/templates/Admin/TranslateApiTranslations/edit.php
@@ -23,7 +23,7 @@
 						]) ?>
 					</li>
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 				</ul>
 			</div>

--- a/templates/Admin/TranslateApiTranslations/index.php
+++ b/templates/Admin/TranslateApiTranslations/index.php
@@ -16,7 +16,7 @@ use Cake\Core\Plugin;
 			<div class="card-body p-0">
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-plus"></i> ' . __d('translate', 'New API Translation'), ['action' => 'add'], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-plus"></i> ' . __d('translate', 'New API Translation'), ['action' => 'add'], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 				</ul>
 			</div>
@@ -51,8 +51,8 @@ use Cake\Core\Plugin;
 								<td><?= $this->Time->nice($translateApiTranslation->created) ?></td>
 								<td class="actions">
 									<div class="btn-group" role="group">
-										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateApiTranslation->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
-										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateApiTranslation->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
+										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateApiTranslation->id], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
+										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateApiTranslation->id], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
 										<?= $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $translateApiTranslation->id], [
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-outline-danger',

--- a/templates/Admin/TranslateApiTranslations/view.php
+++ b/templates/Admin/TranslateApiTranslations/view.php
@@ -13,7 +13,7 @@
 			<div class="card-body p-0">
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-edit"></i> ' . __d('translate', 'Edit API Translation'), ['action' => 'edit', $translateApiTranslation->id], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-edit"></i> ' . __d('translate', 'Edit API Translation'), ['action' => 'edit', $translateApiTranslation->id], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 					<li class="list-group-item">
 						<?= $this->Form->postButton('<i class="fa fa-trash"></i> ' . __d('translate', 'Delete API Translation'), ['action' => 'delete', $translateApiTranslation->id], [
@@ -26,10 +26,10 @@
 						]) ?>
 					</li>
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-list"></i> ' . __d('translate', 'List API Translations'), ['action' => 'index'], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 					<li class="list-group-item">
-						<?= $this->Html->link('<i class="fa fa-plus"></i> ' . __d('translate', 'New API Translation'), ['action' => 'add'], ['escape' => false, 'class' => '']) ?>
+						<?= $this->Html->link('<i class="fa fa-plus"></i> ' . __d('translate', 'New API Translation'), ['action' => 'add'], ['escapeTitle' => false, 'class' => '']) ?>
 					</li>
 				</ul>
 			</div>

--- a/templates/Admin/TranslateBehavior/generate.php
+++ b/templates/Admin/TranslateBehavior/generate.php
@@ -32,7 +32,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 							<?= $this->Html->link(
 								'<i class="fas fa-table"></i> ' . h($table),
 								['action' => 'generate', $table],
-								['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+								['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 							) ?>
 						<?php } ?>
 					</div>
@@ -251,7 +251,7 @@ $fieldsFormatted .= "        ]";
 						<?= $this->Html->link(
 							'<i class="fas fa-arrow-left"></i> ' . __d('translate', 'Back to Overview'),
 							['action' => 'index'],
-							['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary'],
+							['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary'],
 						) ?>
 					</div>
 				</div>

--- a/templates/Admin/TranslateBehavior/index.php
+++ b/templates/Admin/TranslateBehavior/index.php
@@ -20,12 +20,12 @@
 					<?= $this->Html->link(
 						'<i class="fas fa-list"></i> ' . __d('translate', 'Manage Entries'),
 						['controller' => 'I18nEntries', 'action' => 'index'],
-						['escape' => false, 'class' => 'btn btn-light btn-sm'],
+						['escapeTitle' => false, 'class' => 'btn btn-light btn-sm'],
 					) ?>
 					<?= $this->Html->link(
 						'<i class="fas fa-plus"></i> ' . __d('translate', 'Generate Migration'),
 						['action' => 'generate'],
-						['escape' => false, 'class' => 'btn btn-success btn-sm'],
+						['escapeTitle' => false, 'class' => 'btn btn-success btn-sm'],
 					) ?>
 				</div>
 			</div>
@@ -134,13 +134,13 @@
 										<?= $this->Html->link(
 											'<i class="fas fa-eye"></i>',
 											['action' => 'view', $info['shadow_table']],
-											['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View Shadow Table')],
+											['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View Shadow Table')],
 										) ?>
 									<?php } else { ?>
 										<?= $this->Html->link(
 											'<i class="fas fa-plus"></i>',
 											['action' => 'generate', $info['table']],
-											['escape' => false, 'class' => 'btn btn-sm btn-outline-success', 'title' => __d('translate', 'Generate Migration')],
+											['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-success', 'title' => __d('translate', 'Generate Migration')],
 										) ?>
 									<?php } ?>
 								</td>
@@ -208,7 +208,7 @@
 									<?= $this->Html->link(
 										'<i class="fas fa-eye"></i>',
 										['action' => 'view', $info['shadow_table']],
-										['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View Details')],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View Details')],
 									) ?>
 								</td>
 							</tr>
@@ -261,7 +261,7 @@
 									<?= $this->Html->link(
 										'<i class="fas fa-magic"></i> ' . __d('translate', 'Generate Migration'),
 										['action' => 'generate', $info['table']],
-										['escape' => false, 'class' => 'btn btn-sm btn-success'],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-success'],
 									) ?>
 								</td>
 							</tr>

--- a/templates/Admin/TranslateDomains/add.php
+++ b/templates/Admin/TranslateDomains/add.php
@@ -15,7 +15,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateDomains/edit.php
+++ b/templates/Admin/TranslateDomains/edit.php
@@ -27,7 +27,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateDomains/extract.php
+++ b/templates/Admin/TranslateDomains/extract.php
@@ -16,7 +16,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateDomains/index.php
+++ b/templates/Admin/TranslateDomains/index.php
@@ -18,12 +18,12 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
 					['controller' => 'Translate', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate Domain'),
 					['action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -69,12 +69,12 @@ use Cake\Core\Plugin;
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['action' => 'view', $translateDomain->id],
-											['escape' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
 										) ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['action' => 'edit', $translateDomain->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateDomains/setup.php
+++ b/templates/Admin/TranslateDomains/setup.php
@@ -17,7 +17,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateDomains/view.php
+++ b/templates/Admin/TranslateDomains/view.php
@@ -15,7 +15,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit Translate Domain'),
 					['action' => 'edit', $translateDomain->id],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Domain'),
@@ -32,12 +32,12 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate Domain'),
 					['action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateLocales/index.php
+++ b/templates/Admin/TranslateLocales/index.php
@@ -55,8 +55,8 @@ use Cake\Core\Plugin;
 								<td><?= $this->element('Translate.yes_no', ['value' => $translateLocale->active]) ?></td>
 								<td class="actions">
 									<div class="btn-group" role="group">
-										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateLocale->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
-										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateLocale->id], ['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
+										<?= $this->Html->link($this->Icon->render('view'), ['action' => 'view', $translateLocale->id], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary', 'title' => __d('translate', 'View')]) ?>
+										<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateLocale->id], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __d('translate', 'Edit')]) ?>
 										<?= $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $translateLocale->id], [
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-outline-danger',

--- a/templates/Admin/TranslateProjects/add.php
+++ b/templates/Admin/TranslateProjects/add.php
@@ -36,31 +36,27 @@
 					<div class="row g-3">
 						<div class="col-md-12">
 							<?= $this->Form->control('name', [
-								'label' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-6">
 							<?= $this->Form->control('type', [
 								'options' => $translateProject::types(),
-								'label' => '<i class="fas fa-cog"></i> ' . __d('translate', 'Type'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-cog"></i> ' . __d('translate', 'Type'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-6">
 							<?= $this->Form->control('status', [
 								'options' => $translateProject::statuses(),
-								'label' => '<i class="fas fa-toggle-on"></i> ' . __d('translate', 'Status'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-toggle-on"></i> ' . __d('translate', 'Status'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-12">
 							<?= $this->Form->control('path', [
-								'label' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Path'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Path'), 'escape' => false],
 								'placeholder' => __d('translate', 'e.g., plugins/MyPlugin or leave empty for default app path'),
 							]) ?>
 							<small class="form-text text-muted">
@@ -72,8 +68,7 @@
 							<div class="form-check form-switch">
 								<?= $this->Form->control('default', [
 									'type' => 'checkbox',
-									'label' => '<i class="fas fa-star"></i> ' . __d('translate', 'Default Project'),
-									'escape' => false,
+									'label' => ['text' => '<i class="fas fa-star"></i> ' . __d('translate', 'Default Project'), 'escape' => false],
 									'class' => 'form-check-input',
 								]) ?>
 							</div>

--- a/templates/Admin/TranslateProjects/add.php
+++ b/templates/Admin/TranslateProjects/add.php
@@ -15,7 +15,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateProjects/edit.php
+++ b/templates/Admin/TranslateProjects/edit.php
@@ -58,31 +58,27 @@
 					<div class="row g-3">
 						<div class="col-md-12">
 							<?= $this->Form->control('name', [
-								'label' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-6">
 							<?= $this->Form->control('type', [
 								'options' => $translateProject::types(),
-								'label' => '<i class="fas fa-cog"></i> ' . __d('translate', 'Type'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-cog"></i> ' . __d('translate', 'Type'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-6">
 							<?= $this->Form->control('status', [
 								'options' => $translateProject::statuses(),
-								'label' => '<i class="fas fa-toggle-on"></i> ' . __d('translate', 'Status'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-toggle-on"></i> ' . __d('translate', 'Status'), 'escape' => false],
 							]) ?>
 						</div>
 
 						<div class="col-md-12">
 							<?= $this->Form->control('path', [
-								'label' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Path'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Path'), 'escape' => false],
 								'placeholder' => __d('translate', 'e.g., plugins/MyPlugin or leave empty for default app path'),
 							]) ?>
 							<small class="form-text text-muted">
@@ -94,8 +90,7 @@
 							<div class="form-check form-switch">
 								<?= $this->Form->control('default', [
 									'type' => 'checkbox',
-									'label' => '<i class="fas fa-star"></i> ' . __d('translate', 'Default Project'),
-									'escape' => false,
+									'label' => ['text' => '<i class="fas fa-star"></i> ' . __d('translate', 'Default Project'), 'escape' => false],
 									'class' => 'form-check-input',
 								]) ?>
 							</div>

--- a/templates/Admin/TranslateProjects/edit.php
+++ b/templates/Admin/TranslateProjects/edit.php
@@ -27,17 +27,17 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Domains'),
 					['controller' => 'TranslateDomains', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate Domain'),
 					['controller' => 'TranslateDomains', 'action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateProjects/index.php
+++ b/templates/Admin/TranslateProjects/index.php
@@ -18,12 +18,12 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
 					['controller' => 'Translate', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate Project'),
 					['action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -98,12 +98,12 @@ use Cake\Core\Plugin;
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['action' => 'view', $translateProject->id],
-											['escape' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
 										) ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['action' => 'edit', $translateProject->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateProjects/reset.php
+++ b/templates/Admin/TranslateProjects/reset.php
@@ -16,7 +16,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateProjects/view.php
+++ b/templates/Admin/TranslateProjects/view.php
@@ -15,7 +15,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit Translate Project'),
 					['action' => 'edit', $translateProject->id],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Project'),
@@ -32,7 +32,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Projects'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -137,12 +137,12 @@
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['controller' => 'TranslateDomains', 'action' => 'view', $translateDomain->id],
-											['escape' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
 										) ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['controller' => 'TranslateDomains', 'action' => 'edit', $translateDomain->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateStrings/add.php
+++ b/templates/Admin/TranslateStrings/add.php
@@ -15,7 +15,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Strings'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateStrings/add.php
+++ b/templates/Admin/TranslateStrings/add.php
@@ -63,8 +63,7 @@
 					<div class="row g-3">
 						<div class="col-md-12">
 							<?= $this->Form->control('translate_domain_id', [
-								'label' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'), 'escape' => false],
 							]) ?>
 							<small class="form-text text-muted">
 								<?= __d('translate', 'The translation domain this string belongs to (e.g., "default", "validation")') ?>
@@ -73,8 +72,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('name', [
-								'label' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name (Singular)'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name (Singular)'), 'escape' => false],
 								'rows' => 3,
 							]) ?>
 							<small class="form-text text-muted">
@@ -84,8 +82,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('plural', [
-								'label' => '<i class="fas fa-list-ol"></i> ' . __d('translate', 'Plural'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-list-ol"></i> ' . __d('translate', 'Plural'), 'escape' => false],
 								'rows' => 2,
 							]) ?>
 							<small class="form-text text-muted">
@@ -95,8 +92,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('context', [
-								'label' => '<i class="fas fa-info-circle"></i> ' . __d('translate', 'Context'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-info-circle"></i> ' . __d('translate', 'Context'), 'escape' => false],
 								'placeholder' => __d('translate', 'e.g., "navigation", "button", "error message"'),
 							]) ?>
 							<small class="form-text text-muted">
@@ -106,13 +102,13 @@
 
 						<div class="col-md-6">
 							<div class="form-check form-switch">
-								<?= $this->Form->control('is_html', ['type' => 'checkbox', 'label' => '<i class="fas fa-code"></i> ' . __d('translate', 'Is HTML'), 'escape' => false, 'class' => 'form-check-input']) ?>
+								<?= $this->Form->control('is_html', ['type' => 'checkbox', 'label' => ['text' => '<i class="fas fa-code"></i> ' . __d('translate', 'Is HTML'), 'escape' => false], 'class' => 'form-check-input']) ?>
 							</div>
 						</div>
 
 						<div class="col-md-6">
 							<div class="form-check form-switch">
-								<?= $this->Form->control('translate_afterwards', ['type' => 'checkbox', 'label' => '<i class="fas fa-forward"></i> ' . __d('translate', 'Translate Afterwards'), 'escape' => false, 'class' => 'form-check-input']) ?>
+								<?= $this->Form->control('translate_afterwards', ['type' => 'checkbox', 'label' => ['text' => '<i class="fas fa-forward"></i> ' . __d('translate', 'Translate Afterwards'), 'escape' => false], 'class' => 'form-check-input']) ?>
 							</div>
 						</div>
 					</div>

--- a/templates/Admin/TranslateStrings/edit.php
+++ b/templates/Admin/TranslateStrings/edit.php
@@ -27,7 +27,7 @@
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Strings'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Admin/TranslateStrings/edit.php
+++ b/templates/Admin/TranslateStrings/edit.php
@@ -75,8 +75,7 @@
 					<div class="row g-3">
 						<div class="col-md-12">
 							<?= $this->Form->control('translate_domain_id', [
-								'label' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'), 'escape' => false],
 							]) ?>
 							<small class="form-text text-muted">
 								<?= __d('translate', 'The translation domain this string belongs to (e.g., "default", "validation")') ?>
@@ -85,8 +84,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('name', [
-								'label' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name (Singular)'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-tag"></i> ' . __d('translate', 'Name (Singular)'), 'escape' => false],
 								'rows' => 3,
 							]) ?>
 							<small class="form-text text-muted">
@@ -96,8 +94,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('plural', [
-								'label' => '<i class="fas fa-list-ol"></i> ' . __d('translate', 'Plural'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-list-ol"></i> ' . __d('translate', 'Plural'), 'escape' => false],
 								'rows' => 2,
 							]) ?>
 							<small class="form-text text-muted">
@@ -107,8 +104,7 @@
 
 						<div class="col-md-12">
 							<?= $this->Form->control('context', [
-								'label' => '<i class="fas fa-info-circle"></i> ' . __d('translate', 'Context'),
-								'escape' => false,
+								'label' => ['text' => '<i class="fas fa-info-circle"></i> ' . __d('translate', 'Context'), 'escape' => false],
 								'placeholder' => __d('translate', 'e.g., "navigation", "button", "error message"'),
 							]) ?>
 							<small class="form-text text-muted">
@@ -118,13 +114,13 @@
 
 						<div class="col-md-4">
 							<div class="form-check form-switch">
-								<?= $this->Form->control('is_html', ['type' => 'checkbox', 'label' => '<i class="fas fa-code"></i> ' . __d('translate', 'Is HTML'), 'escape' => false, 'class' => 'form-check-input']) ?>
+								<?= $this->Form->control('is_html', ['type' => 'checkbox', 'label' => ['text' => '<i class="fas fa-code"></i> ' . __d('translate', 'Is HTML'), 'escape' => false], 'class' => 'form-check-input']) ?>
 							</div>
 						</div>
 
 						<div class="col-md-4">
 							<div class="form-check form-switch">
-								<?= $this->Form->control('update_references', ['type' => 'checkbox', 'label' => '<i class="fas fa-sync"></i> ' . __d('translate', 'Update Code References'), 'escape' => false, 'class' => 'form-check-input']) ?>
+								<?= $this->Form->control('update_references', ['type' => 'checkbox', 'label' => ['text' => '<i class="fas fa-sync"></i> ' . __d('translate', 'Update Code References'), 'escape' => false], 'class' => 'form-check-input']) ?>
 							</div>
 							<small class="form-text text-muted">
 								<?= __d('translate', 'Update all occurrences in source files to match the new string') ?>
@@ -133,7 +129,7 @@
 
 						<div class="col-md-4">
 							<div class="form-check form-switch">
-								<?= $this->Form->control('translate_afterwards', ['type' => 'checkbox', 'label' => '<i class="fas fa-forward"></i> ' . __d('translate', 'Translate Afterwards'), 'escape' => false, 'class' => 'form-check-input']) ?>
+								<?= $this->Form->control('translate_afterwards', ['type' => 'checkbox', 'label' => ['text' => '<i class="fas fa-forward"></i> ' . __d('translate', 'Translate Afterwards'), 'escape' => false], 'class' => 'form-check-input']) ?>
 							</div>
 						</div>
 					</div>

--- a/templates/Admin/TranslateStrings/extract.php
+++ b/templates/Admin/TranslateStrings/extract.php
@@ -15,8 +15,8 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			</div>
 			<div class="list-group list-group-flush">
 				<?= $this->Html->link(__d('translate', 'List Translate Strings'), ['action' => 'index'], ['class' => 'list-group-item list-group-item-action']) ?>
-				<?= $this->Html->link('<i class="fas fa-search-plus"></i> ' . __d('translate', 'Analyze PO File'), ['action' => 'analyze'], ['class' => 'list-group-item list-group-item-action', 'escape' => false]) ?>
-				<?= $this->Html->link('<i class="fas fa-flask"></i> ' . __d('translate', 'Run i18n Extract'), ['action' => 'runExtract'], ['class' => 'list-group-item list-group-item-action', 'escape' => false]) ?>
+				<?= $this->Html->link('<i class="fas fa-search-plus"></i> ' . __d('translate', 'Analyze PO File'), ['action' => 'analyze'], ['class' => 'list-group-item list-group-item-action', 'escapeTitle' => false]) ?>
+				<?= $this->Html->link('<i class="fas fa-flask"></i> ' . __d('translate', 'Run i18n Extract'), ['action' => 'runExtract'], ['class' => 'list-group-item list-group-item-action', 'escapeTitle' => false]) ?>
 			</div>
 		</div>
 	</aside>

--- a/templates/Admin/TranslateStrings/index.php
+++ b/templates/Admin/TranslateStrings/index.php
@@ -57,15 +57,15 @@ use Cake\Core\Plugin;
 				echo $this->Form->create(null, ['valueSources' => 'query', 'class' => 'row g-3']);
 				?>
 				<div class="col-md-4">
-					<?= $this->Form->control('translate_domain_id', ['empty' => ' - ' . __d('translate', 'noLimitation') . ' - ', 'label' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'), 'escape' => false]) ?>
+					<?= $this->Form->control('translate_domain_id', ['empty' => ' - ' . __d('translate', 'noLimitation') . ' - ', 'label' => ['text' => '<i class="fas fa-folder"></i> ' . __d('translate', 'Domain'), 'escape' => false]]) ?>
 				</div>
 				<div class="col-md-4">
-					<?= $this->Form->control('search', ['placeholder' => __d('translate', 'Search...'), 'label' => '<i class="fas fa-search"></i> ' . __d('translate', 'Search'), 'escape' => false]) ?>
+					<?= $this->Form->control('search', ['placeholder' => __d('translate', 'Search...'), 'label' => ['text' => '<i class="fas fa-search"></i> ' . __d('translate', 'Search'), 'escape' => false]]) ?>
 				</div>
 				<div class="col-md-4">
 					<label class="form-label">&nbsp;</label>
 					<div class="form-check">
-						<?= $this->Form->control('missing_translation', ['type' => 'checkbox', 'hiddenField' => '', 'label' => '<i class="fas fa-exclamation-triangle"></i> ' . __d('translate', 'Missing Translation'), 'escape' => false, 'class' => 'form-check-input']) ?>
+						<?= $this->Form->control('missing_translation', ['type' => 'checkbox', 'hiddenField' => '', 'label' => ['text' => '<i class="fas fa-exclamation-triangle"></i> ' . __d('translate', 'Missing Translation'), 'escape' => false], 'class' => 'form-check-input']) ?>
 					</div>
 				</div>
 				<div class="col-12">

--- a/templates/Admin/TranslateStrings/index.php
+++ b/templates/Admin/TranslateStrings/index.php
@@ -20,22 +20,22 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
 					['controller' => 'Translate', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate String'),
 					['action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-search-plus"></i> ' . __d('translate', 'Analyze PO File'),
 					['action' => 'analyze'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-unlink"></i> ' . __d('translate', 'Orphaned Strings'),
 					['action' => 'orphaned'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -83,7 +83,7 @@ use Cake\Core\Plugin;
 								<?= $this->Html->link(
 									'<i class="fas fa-times"></i> ' . __d('translate', 'Reset'),
 									['action' => 'index'],
-									['class' => 'btn btn-outline-secondary', 'escape' => false],
+									['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 								) ?>
 							<?php } ?>
 						</div>
@@ -187,17 +187,17 @@ use Cake\Core\Plugin;
 										<?= $this->Html->link(
 											$this->Icon->render('translate'),
 											['action' => 'translate', $translateString['id']],
-											['escape' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'Translate'), 'data-bs-toggle' => 'tooltip'],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'Translate'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['action' => 'view', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-info', 'title' => __d('translate', 'View'), 'data-bs-toggle' => 'tooltip'],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-info', 'title' => __d('translate', 'View'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['action' => 'edit', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateStrings/orphaned.php
+++ b/templates/Admin/TranslateStrings/orphaned.php
@@ -20,12 +20,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 				<?= $this->Html->link(
 					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
 					['controller' => 'Translate', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'All Strings'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -136,12 +136,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['action' => 'view', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-info', 'title' => __d('translate', 'View'), 'data-bs-toggle' => 'tooltip'],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-info', 'title' => __d('translate', 'View'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['action' => 'edit', $translateString->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit'), 'data-bs-toggle' => 'tooltip'],
 										); ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateStrings/translate.php
+++ b/templates/Admin/TranslateStrings/translate.php
@@ -28,7 +28,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			<div class="card-header">
 				<h3 class="card-title"><i class="fa-solid fa-language"></i> <?= __d('translate', 'Translate String') ?></h3>
 				<div class="card-tools">
-					<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateString->id, '?' => ['translate_afterwards' => true]], ['escape' => false, 'class' => 'btn btn-tool']); ?>
+					<?= $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $translateString->id, '?' => ['translate_afterwards' => true]], ['escapeTitle' => false, 'class' => 'btn btn-tool']); ?>
 				</div>
 			</div>
 			<div class="card-body">

--- a/templates/Admin/TranslateStrings/view.php
+++ b/templates/Admin/TranslateStrings/view.php
@@ -18,12 +18,12 @@ use Cake\Core\Configure;
 				<?= $this->Html->link(
 					'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit Translate String'),
 					['action' => 'edit', $translateString->id],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-language"></i> ' . __d('translate', 'Translate'),
 					['action' => 'translate', $translateString->id],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete'),
@@ -40,12 +40,12 @@ use Cake\Core\Configure;
 				<?= $this->Html->link(
 					'<i class="fas fa-list"></i> ' . __d('translate', 'List Translate Strings'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus"></i> ' . __d('translate', 'New Translate String'),
 					['action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -270,12 +270,12 @@ use Cake\Core\Configure;
 					<?= $this->Html->link(
 						'<i class="fas fa-eye"></i> ' . __d('translate', 'View Domain'),
 						['controller' => 'TranslateDomains', 'action' => 'view', $translateString->translate_domain->id],
-						['escape' => false, 'class' => 'btn btn-sm btn-outline-primary'],
+						['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
 					) ?>
 					<?= $this->Html->link(
 						'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit Domain'),
 						['controller' => 'TranslateDomains', 'action' => 'edit', $translateString->translate_domain->id],
-						['escape' => false, 'class' => 'btn btn-sm btn-outline-secondary'],
+						['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary'],
 					) ?>
 				</div>
 			</div>

--- a/templates/Admin/TranslateTerms/edit.php
+++ b/templates/Admin/TranslateTerms/edit.php
@@ -32,17 +32,17 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-comments"></i> ' . __d('translate', 'List Translate Terms'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-language"></i> ' . __d('translate', 'List Translate Strings'),
 					['controller' => 'TranslateStrings', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate String'),
 					['controller' => 'TranslateStrings', 'action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -78,7 +78,7 @@ use Cake\Core\Plugin;
 						<?= $this->Html->link(
 							'<i class="fas fa-times"></i> ' . __d('translate', 'Cancel'),
 							['action' => 'view', $translateTerm->id],
-							['class' => 'btn btn-outline-secondary', 'escape' => false],
+							['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 						) ?>
 					</div>
 				</div>

--- a/templates/Admin/TranslateTerms/index.php
+++ b/templates/Admin/TranslateTerms/index.php
@@ -19,22 +19,22 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-home"></i> ' . __d('translate', 'Overview'),
 					['controller' => 'Translate', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-language"></i> ' . __d('translate', 'List Translate Strings'),
 					['controller' => 'TranslateStrings', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate String'),
 					['controller' => 'TranslateStrings', 'action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-globe"></i> ' . __d('translate', 'List Locales'),
 					['controller' => 'TranslateLocales', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>
@@ -72,7 +72,7 @@ use Cake\Core\Plugin;
 								<?= $this->Html->link(
 									'<i class="fas fa-times"></i> ' . __d('translate', 'Reset'),
 									['action' => 'index'],
-									['class' => 'btn btn-outline-secondary', 'escape' => false],
+									['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 								) ?>
 							<?php } ?>
 						</div>
@@ -145,12 +145,12 @@ use Cake\Core\Plugin;
 										<?= $this->Html->link(
 											$this->Icon->render('view'),
 											['action' => 'view', $translateTerm->id],
-											['escape' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-primary', 'title' => __d('translate', 'View')],
 										) ?>
 										<?= $this->Html->link(
 											$this->Icon->render('edit'),
 											['action' => 'edit', $translateTerm->id],
-											['escape' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
+											['escapeTitle' => false, 'class' => 'btn btn-outline-secondary', 'title' => __d('translate', 'Edit')],
 										) ?>
 										<?= $this->Form->postButton(
 											$this->Icon->render('delete'),

--- a/templates/Admin/TranslateTerms/index.php
+++ b/templates/Admin/TranslateTerms/index.php
@@ -56,10 +56,10 @@ use Cake\Core\Plugin;
 				echo $this->Form->create(null, ['valueSources' => 'query', 'class' => 'row g-3']);
 				?>
 				<div class="col-md-6">
-					<?= $this->Form->control('translate_locale_id', ['empty' => ' - ' . __d('translate', 'noLimitation') . ' - ', 'label' => '<i class="fas fa-globe"></i> ' . __d('translate', 'Locale'), 'escape' => false]) ?>
+					<?= $this->Form->control('translate_locale_id', ['empty' => ' - ' . __d('translate', 'noLimitation') . ' - ', 'label' => ['text' => '<i class="fas fa-globe"></i> ' . __d('translate', 'Locale'), 'escape' => false]]) ?>
 				</div>
 				<div class="col-md-6">
-					<?= $this->Form->control('search', ['placeholder' => __d('translate', 'Search...'), 'label' => '<i class="fas fa-search"></i> ' . __d('translate', 'Search'), 'escape' => false]) ?>
+					<?= $this->Form->control('search', ['placeholder' => __d('translate', 'Search...'), 'label' => ['text' => '<i class="fas fa-search"></i> ' . __d('translate', 'Search'), 'escape' => false]]) ?>
 				</div>
 				<div class="col-12">
 					<div class="d-flex justify-content-end">

--- a/templates/Admin/TranslateTerms/pending.php
+++ b/templates/Admin/TranslateTerms/pending.php
@@ -141,7 +141,7 @@
 							<?= $this->Html->link(
 								'<i class="fas fa-eye"></i>',
 								['action' => 'view', $term->id],
-								['escape' => false, 'class' => 'btn btn-sm btn-info', 'title' => __d('translate', 'View')]
+								['escapeTitle' => false, 'class' => 'btn btn-sm btn-info', 'title' => __d('translate', 'View')]
 							) ?>
 							<?= $this->Form->postButton(
 								'<i class="fas fa-check"></i>',

--- a/templates/Admin/TranslateTerms/view.php
+++ b/templates/Admin/TranslateTerms/view.php
@@ -18,7 +18,7 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-edit"></i> ' . __d('translate', 'Edit Translate Term'),
 					['action' => 'edit', $translateTerm->id],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Form->postButton(
 					'<i class="fas fa-trash"></i> ' . __d('translate', 'Delete Translate Term'),
@@ -35,17 +35,17 @@ use Cake\Core\Plugin;
 				<?= $this->Html->link(
 					'<i class="fas fa-comments"></i> ' . __d('translate', 'List Translate Terms'),
 					['action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-language"></i> ' . __d('translate', 'List Translate Strings'),
 					['controller' => 'TranslateStrings', 'action' => 'index'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 				<?= $this->Html->link(
 					'<i class="fas fa-plus-circle"></i> ' . __d('translate', 'New Translate String'),
 					['controller' => 'TranslateStrings', 'action' => 'add'],
-					['escape' => false, 'class' => 'list-group-item list-group-item-action'],
+					['escapeTitle' => false, 'class' => 'list-group-item list-group-item-action'],
 				) ?>
 			</div>
 		</div>

--- a/templates/Translate/index.php
+++ b/templates/Translate/index.php
@@ -64,7 +64,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 									</div>',
 									['action' => 'terms'],
-									['escape' => false, 'class' => 'text-decoration-none'],
+									['escapeTitle' => false, 'class' => 'text-decoration-none'],
 								) ?>
 							</div>
 							<div class="col-3">
@@ -77,7 +77,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 									</div>',
 									['action' => 'terms'],
-									['escape' => false, 'class' => 'text-decoration-none'],
+									['escapeTitle' => false, 'class' => 'text-decoration-none'],
 								) ?>
 							</div>
 							<div class="col-3">
@@ -90,7 +90,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 									</div>',
 									['action' => 'terms'],
-									['escape' => false, 'class' => 'text-decoration-none'],
+									['escapeTitle' => false, 'class' => 'text-decoration-none'],
 								) ?>
 							</div>
 							<div class="col-3">
@@ -103,7 +103,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 									</div>',
 									['action' => 'terms'],
-									['escape' => false, 'class' => 'text-decoration-none'],
+									['escapeTitle' => false, 'class' => 'text-decoration-none'],
 								) ?>
 							</div>
 						</div>
@@ -149,7 +149,7 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 										</div>
 									</div>',
 									['action' => 'terms', '?' => ['domain' => $domainName]],
-									['class' => 'list-group-item list-group-item-action', 'escape' => false],
+									['class' => 'list-group-item list-group-item-action', 'escapeTitle' => false],
 								) ?>
 							<?php } ?>
 						</div>
@@ -159,12 +159,12 @@ $totalColor = $this->Translation->getColor($totalCoverage);
 						<?= $this->Html->link(
 							'<i class="fas fa-play"></i> ' . __d('translate', 'Start Translating Next'),
 							['action' => 'translate'],
-							['class' => 'btn btn-success btn-lg', 'escape' => false],
+							['class' => 'btn btn-success btn-lg', 'escapeTitle' => false],
 						); ?>
 						<?= $this->Html->link(
 							'<i class="fas fa-list"></i> ' . __d('translate', 'Browse All Terms'),
 							['action' => 'terms'],
-							['class' => 'btn btn-primary', 'escape' => false],
+							['class' => 'btn btn-primary', 'escapeTitle' => false],
 						); ?>
 					</div>
 				</div>

--- a/templates/Translate/terms.php
+++ b/templates/Translate/terms.php
@@ -182,7 +182,7 @@
 							<?= $this->Html->link(
 								'<i class="fas fa-language"></i>',
 								['action' => 'translate', $translateString->translate_domain->name, $translateString->id],
-								['escape' => false, 'class' => 'btn btn-sm btn-primary', 'title' => __d('translate', 'Translate')]
+								['escapeTitle' => false, 'class' => 'btn btn-sm btn-primary', 'title' => __d('translate', 'Translate')]
 							) ?>
 						</td>
 					</tr>

--- a/templates/Translate/translate.php
+++ b/templates/Translate/translate.php
@@ -19,7 +19,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			<?= $this->Html->link(
 				'<i class="fas fa-arrow-left"></i> ' . __d('translate', 'Overview'),
 				['controller' => 'Translate', 'action' => 'index'],
-				['class' => 'btn btn-sm btn-secondary', 'escape' => false]
+				['class' => 'btn btn-sm btn-secondary', 'escapeTitle' => false]
 			) ?>
 		</div>
 		<div class="card-body p-2">


### PR DESCRIPTION
## Summary

Three template-escaping fixes in admin templates and breadcrumbs:

- **Remove redundant `h()` wrap around `Html->link()` titles** (4 breadcrumb spots in `Admin/I18nEntries/`). `Html->link()` already escapes its title argument; wrapping in `h()` caused double-encoding (e.g. `&` → `&amp;amp;`) for table names containing those characters.
- **Switch `'escape' => false` to `'escapeTitle' => false`** in 125 `Html->link()` / `Form->postLink()` / `Form->button()` calls that render an icon-prefixed title. `'escape' => false` also disables escaping of url attributes (href, title, class), which is unsafe whenever any of those carry user-derived data. `'escapeTitle' => false` scopes the opt-out to the title only.
- **Refactor 28 `Form->control()` calls** with HTML labels to use the array-label form (`'label' => ['text' => '<i ...></i> Label', 'escape' => false]`) instead of top-level `'escape' => false`. The top-level form also disables escaping of select option values and certain attributes — the label-array form scopes the opt-out to the label only.

PHP syntax checked on all modified files.