### PR TITLE
Refresh translate.pot from current source

### DIFF
--- a/resources/locales/translate.pot
+++ b/resources/locales/translate.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2025-11-21 15:13+0100\n"
+"POT-Creation-Date: 2026-05-04 03:29+0200\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -14,2596 +14,2215 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:53
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:79
-msgid "The translate api translation has been saved."
+msgid "Invalid translation table name."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:58
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:84
-msgid "The translate api translation could not be saved. Please, try again."
+msgid "Translation table not found."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:102
-msgid "The translate api translation has been deleted."
+msgid "Invalid translation table."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateApiTranslationsController.php:104
-msgid "The translate api translation could not be deleted. Please, try again."
+msgid "Cannot add translation for the source locale. Edit the base record instead."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:444
-msgid "Table {0} not found"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:482
-msgid "Please select at least one field to translate"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:697
-msgid "Missing required data"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:715
-msgid "Migration file already exists: {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:722
-msgid "Failed to write migration file"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateBehaviorController.php:727
-msgid "Migration file created successfully: {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:221
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:222
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:386
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:889
-msgid "No project selected."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:255
-msgid "Reset complete for current project."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:257
-msgid "No options selected."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:312
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:356
-msgid "Invalid locale"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:328
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:371
-msgid "Language not found or not active"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:336
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:379
-msgid "Language switched to {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:354
-msgid "Invalid project"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateController.php:362
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:398
-msgid "Project switched to {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:50
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:96
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:128
-msgid "Domain not found."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:70
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:102
-msgid "The translate domain has been saved."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:75
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:107
-msgid "The translate domain could not be saved. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:132
-msgid "The translate domain has been deleted."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateDomainsController.php:134
-msgid "The translate domain could not be deleted. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:120
-msgid "{0} new language(s) added"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:135
-msgid "Validation errors: {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:137
-msgid "Could not save languages. Please try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:140
-msgid "No languages selected."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:174
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:219
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:249
-msgid "Locale not found."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:194
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:225
-msgid "The translate language has been saved."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:199
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:230
-msgid "The translate language could not be saved. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:253
-msgid "The translate language has been deleted."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateLocalesController.php:255
-msgid "The translate language could not be deleted. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:58
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:86
-msgid "The translate project has been saved."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:63
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:91
-msgid "The translate project could not be saved. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:109
-msgid "The translate project has been deleted."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:111
-msgid "The translate project could not be deleted. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:122
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:46
-msgid "Translate Terms"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:123
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:41
-msgid "Translate Strings"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:124
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:35
-msgid "Translate Domains"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateProjectsController.php:133
-msgid "Done"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:87
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:136
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:192
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:484
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:620
-msgid "String not found."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:104
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:154
-msgid "The translate string has been saved."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:113
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:163
-msgid "The translate string could not be saved. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:150
-msgid "Updated {0} reference(s) in source files."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:196
-msgid "The translate string has been deleted."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:198
-msgid "The translate string could not be deleted. Please, try again."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:344
-msgid "Done: {0}/{1}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:493
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:214
-msgid "You need at least one language to translate"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:525
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:583
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:245
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:303
-msgid "No more open translations."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:588
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/TranslateController.php:308
 msgid "Translation saved successfully."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:636
-msgid "File is not writable: {0}"
+msgid "Could not save translation. Please try again."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:640
+msgid "Cannot edit translation for the source locale. Edit the base record instead."
+msgstr ""
+
+msgid "Translation updated successfully."
+msgstr ""
+
+msgid "{0} locale(s) translated successfully."
+msgstr ""
+
+msgid "{0} locale(s) could not be translated."
+msgstr ""
+
+msgid "No translations needed."
+msgstr ""
+
+msgid "Base table not found."
+msgstr ""
+
+msgid "No records selected."
+msgstr ""
+
+msgid "{0} translation(s) created successfully."
+msgstr ""
+
+msgid "{0} translation(s) could not be created."
+msgstr ""
+
+msgid "The translation has been saved."
+msgstr ""
+
+msgid "The translation could not be saved. Please try again."
+msgstr ""
+
+msgid "The translation has been deleted."
+msgstr ""
+
+msgid "The translation could not be deleted. Please try again."
+msgstr ""
+
+msgid "No entries selected for translation."
+msgstr ""
+
+msgid "{0} entries translated successfully."
+msgstr ""
+
+msgid "({0} from memory, {1} from API)"
+msgstr ""
+
+msgid "{0} entries could not be translated."
+msgstr ""
+
+msgid "This table does not have an auto field."
+msgstr ""
+
+msgid "No entries selected."
+msgstr ""
+
+msgid "{0} entries updated."
+msgstr ""
+
+msgid "No target locales configured. Please specify locales to sync."
+msgstr ""
+
+msgid "{0} translation entries created."
+msgstr ""
+
+msgid "All entries are already synced."
+msgstr ""
+
+msgid "The translate api translation has been saved."
+msgstr ""
+
+msgid "The translate api translation could not be saved. Please, try again."
+msgstr ""
+
+msgid "The translate api translation has been deleted."
+msgstr ""
+
+msgid "The translate api translation could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Table {0} not found"
+msgstr ""
+
+msgid "Please select at least one field to translate"
+msgstr ""
+
+msgid "Missing required data"
+msgstr ""
+
+msgid "Invalid strategy"
+msgstr ""
+
+msgid "No valid fields selected"
+msgstr ""
+
+msgid "Invalid migration name"
+msgstr ""
+
+msgid "Failed to resolve migration path"
+msgstr ""
+
+msgid "Resolved path escapes migrations directory"
+msgstr ""
+
+msgid "Migration file already exists: {0}"
+msgstr ""
+
+msgid "Failed to write migration file"
+msgstr ""
+
+msgid "Migration file created successfully: {0}"
+msgstr ""
+
+msgid "No project selected."
+msgstr ""
+
+msgid "Reset complete for current project."
+msgstr ""
+
+msgid "No options selected."
+msgstr ""
+
+msgid "Invalid locale"
+msgstr ""
+
+msgid "Language not found or not active"
+msgstr ""
+
+msgid "Language switched to {0}"
+msgstr ""
+
+msgid "Invalid project"
+msgstr ""
+
+msgid "Project switched to {0}"
+msgstr ""
+
+msgid "Domain not found."
+msgstr ""
+
+msgid "The translate domain has been saved."
+msgstr ""
+
+msgid "The translate domain could not be saved. Please, try again."
+msgstr ""
+
+msgid "The translate domain has been deleted."
+msgstr ""
+
+msgid "The translate domain could not be deleted. Please, try again."
+msgstr ""
+
+msgid "{0} new language(s) added"
+msgstr ""
+
+msgid "Validation errors: {0}"
+msgstr ""
+
+msgid "Could not save languages. Please try again."
+msgstr ""
+
+msgid "No languages selected."
+msgstr ""
+
+msgid "Locale not found."
+msgstr ""
+
+msgid "The translate language has been saved."
+msgstr ""
+
+msgid "The translate language could not be saved. Please, try again."
+msgstr ""
+
+msgid "The translate language has been deleted."
+msgstr ""
+
+msgid "The translate language could not be deleted. Please, try again."
+msgstr ""
+
+msgid "The translate project has been saved."
+msgstr ""
+
+msgid "The translate project could not be saved. Please, try again."
+msgstr ""
+
+msgid "The translate project has been deleted."
+msgstr ""
+
+msgid "The translate project could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Translate Terms"
+msgstr ""
+
+msgid "Translate Strings"
+msgstr ""
+
+msgid "Translate Domains"
+msgstr ""
+
+msgid "Done"
+msgstr ""
+
+msgid "{0} orphaned strings deleted."
+msgstr ""
+
+msgid "{0} orphaned strings marked as inactive."
+msgstr ""
+
+msgid "String not found."
+msgstr ""
+
+msgid "The translate string has been saved."
+msgstr ""
+
+msgid "The translate string could not be saved. Please, try again."
+msgstr ""
+
+msgid "Updated {0} reference(s) in source files."
+msgstr ""
+
+msgid "The translate string has been deleted."
+msgstr ""
+
+msgid "The translate string could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Done: {0}/{1}"
+msgstr ""
+
+msgid "You need at least one language to translate"
+msgstr ""
+
+msgid "No more open translations."
+msgstr ""
+
 msgid "File updated successfully. Please commit your changes!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:642
 msgid "Failed to write file"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:689
+msgid "Source file not found: {0}"
+msgstr ""
+
 msgid "Project path not found: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:708
 msgid "File not writable: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:833
 msgid "Please provide PO file content or upload a file."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:871
 msgid "File not found: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:942
 msgid "No valid paths found to scan."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:975
+msgid "Output path must be inside the project: {0}"
+msgstr ""
+
 msgid "Failed to create output directory: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:986
 msgid "Output directory is not writable: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1091
 msgid "Dry run completed. Preview of extracted strings shown below."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1116
 msgid "Extraction completed. Generated: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1147
 msgid "Import partially completed: {0} of {1} strings imported. Errors: {2}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1149
 msgid "Import completed: {0} of {1} strings imported to database."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1153
 msgid "Extraction completed but no POT files were generated. Check if your code uses __d('{0}', ...) calls."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1156
 msgid "Extraction completed with return code: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateStringsController.php:1159
 msgid "Extraction failed: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:68
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:88
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:128
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:261
 msgid "Term not found."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:94
 msgid "The translate term has been saved."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:99
 msgid "The translate term could not be saved. Please, try again."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:132
 msgid "The translate term has been deleted."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:134
 msgid "The translate term could not be deleted. Please, try again."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:239
 msgid "{0} translation(s) have been confirmed."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:241
 msgid "No translations were confirmed."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:268
 msgid "Translation has been confirmed."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Controller/Admin/TranslateTermsController.php:270
 msgid "Could not confirm translation."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:44
+msgid "Translate admin backend is not configured. Set Translate.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "Translate admin access denied."
+msgstr ""
+
 msgid "Inactive Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:45
 msgid "Hidden Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:46
 msgid "Public Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:74
 msgid "CakePHP App"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:75
 msgid "CakePHP Plugin"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/src/Model/Entity/TranslateProject.php:76
 msgid "Other Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:11
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/convert.php:13
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:546
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:11
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:11
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:41
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:11
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:87
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:164
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:232
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/add.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:13
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:49
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/add.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:38
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:11
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:51
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:13
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:113
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:13
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:107
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:98
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:90
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:121
-msgid "Actions"
+msgid "I18n Entries"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:14
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/convert.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:20
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:20
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:20
-msgid "Overview"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:22
-msgid "bestPractice"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:25
-msgid "Common things"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:27
-msgid "Always code in English (not only the code - all translation strings should be that way as well)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:28
-msgid "Use short terminology for sentences and longer translations - camelCased ideally: \"breadcrumpTrail\""
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:29
-msgid "Group them together by their meaning, like \"valErr...\" for Validation Errors, or \"textWhy..\" for some long text/explanation on the website"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/best_practice.php:31
-msgid "With these tips you can easily use the translate plugin to generate your translation base - and let translaters do their job."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/convert.php:25
-msgid "Result"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/convert.php:35
-msgid "Convert text"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/convert.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:42
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/add.php:44
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:49
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:109
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:85
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/add.php:42
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:53
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:49
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:89
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:104
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:84
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:123
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:52
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:137
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:66
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:68
-msgid "Submit"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:36
-msgid "Edit Project"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:41
-msgid "All Projects"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:46
-msgid "Start Translating"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:50
-msgid "No project selected"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:52
-msgid "Create"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:65
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:87
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:27
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:63
-msgid "Locales"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:72
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:76
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:17
-msgid "Domains"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:79
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:89
-msgid "Strings"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:86
-msgid "Terms"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:96
-msgid "Overall Coverage"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:111
-msgid "Coverage by Language"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:125
-msgid "Translation Quality"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:127
-msgid "Batch Confirm"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:136
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:429
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:37
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:59
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:94
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:85
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:77
-#: ./vendor/dereuromark/cakephp-translate/templates/element/coverage_table.php:10
-msgid "Locale"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:137
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:445
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:152
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:95
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:92
-msgid "Confirmed"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:138
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:449
-msgid "Unconfirmed"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:139
-msgid "Progress"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:173
-msgid "Confirmed translations have been reviewed and approved for production use."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:188
-msgid "Recent Strings"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:209
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:199
-msgid "View Details"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:215
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:282
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:516
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:140
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:24
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:185
-msgid "Translate"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:225
-msgid "String Details"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:231
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:87
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:118
-msgid "String"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:236
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:87
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:92
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:87
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:108
-msgid "Plural"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:242
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:98
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:103
-msgid "Context"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:247
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:433
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:66
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:71
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:54
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:74
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:86
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:35
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:117
-msgid "Domain"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:251
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:437
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:80
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:89
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:112
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:101
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:256
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:89
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:104
-msgid "Modified"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:255
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:555
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:594
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:40
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:52
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:76
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:85
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:111
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:96
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:252
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:100
-msgid "Created"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:260
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:91
-msgid "Last Import"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:265
-msgid "Flags"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:287
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:54
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:72
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:58
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:101
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:133
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:145
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:148
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:144
-msgid "View"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:307
-msgid "Recent Translations"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:326
-msgid "View Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:332
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:458
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:55
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:77
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:59
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:106
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:138
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:150
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:153
 msgid "Edit"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:344
-msgid "Translation Change"
+msgid "Edit Translation"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:367
-msgid "Changes from last edit"
+msgid "Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:373
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:639
-msgid "Unified Diff"
+msgid "Foreign Key"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:406
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:211
-msgid "Details"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:409
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:58
-msgid "Original String"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:413
-msgid "Current Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:418
-msgid "Plural Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:424
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:73
-msgid "Comment"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:441
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:163
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:55
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:70
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:65
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:124
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:32
-msgid "Status"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:463
-msgid "View String"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:485
-msgid "Recently Imported Strings"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:496
-msgid "Has plural form"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:499
-msgid "Contains HTML"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:535
-msgid "Audit Trail"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:542
-msgid "Time"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:543
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:113
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:47
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:62
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:52
-msgid "Type"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:544
-msgid "Source"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:545
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:84
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:116
-msgid "ID"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:557
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:596
-msgid "Updated"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:559
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:598
-msgid "Deleted"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:607
-msgid "Audit Information"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:612
-msgid "Timestamp"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:616
-msgid "Transaction"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:621
-msgid "Full Details"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:624
-msgid "View in AuditStash"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:690
-msgid "Changed Fields"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:696
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:745
 msgid "Field"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:697
-msgid "Before"
+msgid "Source Text"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:698
-msgid "After"
+msgid "original"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:739
-msgid "Created Data"
+msgid "Translation"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:746
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:32
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:35
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:65
-msgid "Value"
+msgid "Auto-translated"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:782
-msgid "Available Features"
+msgid "Check this if the translation was machine-generated. Uncheck if you manually edited it."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:790
-msgid "Audit Logging"
+msgid "Save"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:794
-msgid "AuditStash Plugin"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:800
-msgid "Plugin installed but disabled in config"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:801
-msgid "Disabled"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:805
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:829
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:190
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:68
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:109
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:81
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:240
-msgid "Active"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:810
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:833
-msgid "Not Installed"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:819
-msgid "Advanced Search"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:823
-msgid "FriendsOfCake/Search Plugin"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:842
-msgid "Auto-Translation API"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:843
-msgid "Google Translate, DeepL, etc."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:852
-msgid "Available"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:856
-msgid "Not Available"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:874
-msgid "Quick Actions"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:883
-msgid "Import from PO/POT files"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:888
-msgid "Export to PO files"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:893
-msgid "Import locales from filesystem"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:898
-msgid "TranslateBehavior & Shadow Tables"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:903
-msgid "Best Practices"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/index.php:909
-msgid "Reset Project Data"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:23
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:28
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:41
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:78
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:73
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:93
-msgid "Reset"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:36
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:64
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:75
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:44
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:44
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:59
-msgid "Selection"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:48
-msgid "or"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:53
-msgid "Hard reset Translate (fully truncate all tables)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/Translate/reset.php:55
-msgid "Sure?"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:22
-msgid "List API Translations"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:26
-msgid "Add API Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:31
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:34
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:36
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:58
-msgid "Key"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:33
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:36
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:37
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:40
-msgid "From"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:34
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:37
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:38
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:44
-msgid "To"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/add.php:35
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:38
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:48
-msgid "Engine"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:56
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:82
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:60
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:111
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:143
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:155
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:29
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:158
-msgid "Delete"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:56
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:82
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:23
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:60
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:111
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:23
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:143
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:155
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:31
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:23
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:158
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:26
-msgid "Are you sure you want to delete # {0}?"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/edit.php:29
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:16
-msgid "Edit API Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:25
-msgid "New API Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/index.php:29
-msgid "API Translations"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateApiTranslations/view.php:19
-msgid "Delete API Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:21
-msgid "Generate TranslateBehavior Migration"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:25
-msgid "Select a table to generate a shadow table migration for CakePHP TranslateBehavior."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:19
-msgid "TranslateBehavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:150
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:131
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:250
-msgid "Generate Migration"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:59
-msgid "Generate Migration for Table: {0}"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:64
-msgid "This will create a shadow table named"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:66
-msgid "to store translations for the selected fields."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:77
-msgid "Configuration"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:84
-msgid "Translation Strategy"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:88
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:86
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:159
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:40
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:75
-msgid "Shadow Table"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:89
-msgid "EAV (Entity-Attribute-Value)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:102
-msgid "Creates columns for each field. Better performance, recommended."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:103
-msgid "Flexible, stores each field translation as a row. More flexible but slower."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:111
-msgid "Select Fields to Translate"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:116
-msgid "No translatable fields found in this table."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:138
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:38
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:53
-msgid "Select All"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:141
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:54
-msgid "Deselect All"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:163
-msgid "Next Steps"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:167
-msgid "Copy the migration code"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:169
-msgid "Save to"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:173
-msgid "Run:"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:177
-msgid "Add to your Table class:"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:207
-msgid "Generated Migration Code"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:216
-msgid "Copy to Clipboard"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:226
-msgid "Save Migration File"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:231
-msgid "Back to Overview"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:242
-msgid "Configure and Generate"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:243
-msgid "Select the fields you want to translate and click \"Generate Migration\"."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/generate.php:263
-msgid "Migration code copied to clipboard!"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:17
-msgid "CakePHP TranslateBehavior Overview"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:22
-msgid "This page shows where CakePHP's built-in TranslateBehavior is used in your application and helps you add translation support to more tables."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:36
-msgid "Shadow Tables (_i18n)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:45
-msgid "Models Using Behavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:54
-msgid "Candidate Tables"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:63
-msgid "Orphaned Shadow Tables"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:75
-msgid "Models Using TranslateBehavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:82
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:229
-msgid "Table"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:83
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:54
-msgid "Model Class"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:84
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:161
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:69
-msgid "Strategy"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:85
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:79
-msgid "Translated Fields"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:106
-msgid "All fields"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:116
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:49
-msgid "Missing"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:125
-msgid "View Shadow Table"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:152
-msgid "Existing Shadow Tables (_i18n)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:160
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:43
-msgid "Base Table"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:162
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:113
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:102
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:119
-msgid "Translations"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:192
-msgid "Orphaned"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:220
-msgid "Tables That Could Use Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:221
-msgid "No shadow table yet"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:230
-msgid "Translatable Fields"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:231
-msgid "Field Count"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:271
-msgid "About CakePHP TranslateBehavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:275
-msgid "CakePHP's TranslateBehavior allows you to translate database fields by storing translations in shadow tables with the \"_i18n\" suffix."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:278
-msgid "Translation Strategies"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:282
-msgid "Default strategy. Stores each translated field as a separate row with columns: locale, field, content."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:286
-msgid "Creates separate columns for each translated field. Better performance but less flexible."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:292
-msgid "Learn more:"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/index.php:294
-msgid "CakePHP TranslateBehavior Documentation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:47
-msgid "Exists"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:59
-msgid "Has TranslateBehavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:63
-msgid "No TranslateBehavior"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:73
-msgid "Entity-Attribute-Value"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:105
-msgid "Table Schema"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:112
-msgid "Column"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:114
-msgid "Length"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:115
-msgid "Null"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:116
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:60
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:56
-msgid "Default"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:165
-msgid "Translation Data"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:166
-msgid "first 20 rows"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:217
-msgid "How to Use"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:221
-msgid "This table uses the EAV (Entity-Attribute-Value) strategy where:"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:223
-msgid "The language/locale code (e.g., en_US, de_DE)"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:224
-msgid "The model name"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:225
-msgid "ID of the record in the base table"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:226
-msgid "Name of the translated field"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:227
-msgid "The translated value"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:230
-msgid "This table uses the Shadow Table strategy where each translated field has its own column."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:236
-msgid "Note"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateBehavior/view.php:237
-msgid "The model class exists but doesn't have the TranslateBehavior attached. Add it to your Table class:"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/add.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:26
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:26
-msgid "List Translate Domains"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/add.php:30
-msgid "Add Translate Domain"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/add.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:53
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:113
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:89
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:93
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:108
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:88
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:127
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:141
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:72
 msgid "Cancel"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/edit.php:35
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:16
-msgid "Edit Translate Domain"
+msgid "Auto-Translate"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:26
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:27
-msgid "Information"
+msgid "Use machine translation to fill in the translation. This will overwrite the current content."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:29
-msgid "POT Files"
+msgid "Source Language"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:31
-msgid "POT (Portable Object Template) files contain the source strings to be translated."
+msgid "Translate Now"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:34
-msgid "PO Files"
+msgid "Glossary"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:36
-msgid "PO (Portable Object) files contain translations for a specific language."
+msgid "Copy to clipboard"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/source.php:9
-msgid "Source Code"
+msgid "Click to copy translations from PO files"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:41
-msgid "Extract translation strings directly from your application source code."
+msgid "Tips"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:53
-msgid "Extract Translation Strings"
+msgid "Manually editing the translation will automatically uncheck the \"Auto-translated\" flag."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:60
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:36
-msgid "From POT File"
+msgid "Use glossary suggestions for consistent terminology."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:71
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:51
-msgid "From PO File"
+msgid "Machine translations can be refined by editing and unchecking the auto flag."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:82
-msgid "From Source Code"
+msgid "-- All Locales --"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:87
-msgid "Extract from source code"
+msgid "-- All Fields --"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:95
+msgid "-- All --"
+msgstr ""
+
+msgid "Auto"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Search"
+msgstr ""
+
+msgid "Search content..."
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Select All"
+msgstr ""
+
+msgid "Select None"
+msgstr ""
+
+msgid "Mark as Manual"
+msgstr ""
+
+msgid "Mark as Auto"
+msgstr ""
+
+msgid "Auto-Translate Selected"
+msgstr ""
+
+msgid "ID"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete this entry?"
+msgstr ""
+
+msgid "Base Table View"
+msgstr ""
+
+msgid "Showing records from the base table with their translation status per locale."
+msgstr ""
+
+msgid "Translated"
+msgstr ""
+
+msgid "Missing"
+msgstr ""
+
+msgid "Search by {0}..."
+msgstr ""
+
+msgid "Search..."
+msgstr ""
+
+msgid "Locales"
+msgstr ""
+
+msgid "Auto-translate Selected"
+msgstr ""
+
+msgid "Translated Fields"
+msgstr ""
+
+msgid "Partially translated"
+msgstr ""
+
+msgid "Empty translation"
+msgstr ""
+
+msgid "Edit {0}"
+msgstr ""
+
+msgid "Not translated"
+msgstr ""
+
+msgid "Add {0}"
+msgstr ""
+
+msgid "View All"
+msgstr ""
+
+msgid "No records found."
+msgstr ""
+
+msgid "Please select at least one record."
+msgstr ""
+
+msgid "Auto-translate {0} selected record(s)?"
+msgstr ""
+
+msgid "Legend"
+msgstr ""
+
+msgid "All fields translated (manual)"
+msgstr ""
+
+msgid "All fields translated (auto)"
+msgstr ""
+
+msgid "Translation exists but empty"
+msgstr ""
+
+msgid "No translation record"
+msgstr ""
+
+msgid "Translate"
+msgstr ""
+
+msgid "Translation Entries"
+msgstr ""
+
+msgid "TranslateBehavior Tables"
+msgstr ""
+
+msgid "Manage translations stored in TranslateBehavior tables. Supports both EAV (*_i18n) and ShadowTable (*_translations) strategies."
+msgstr ""
+
+msgid "Available Locales"
+msgstr ""
+
+msgid "No TranslateBehavior tables found. Create them using the TranslateBehavior generator or add the Translate behavior to your models."
+msgstr ""
+
+msgid "Go to Generator"
+msgstr ""
+
+msgid "Base table missing"
+msgstr ""
+
+msgid "Table"
+msgstr ""
+
+msgid "Strategy"
+msgstr ""
+
+msgid "Base Records"
+msgstr ""
+
+msgid "Entries"
+msgstr ""
+
+msgid "Auto/Manual"
+msgstr ""
+
+msgid "Auto Field"
+msgstr ""
+
+msgid "View Entries"
+msgstr ""
+
+msgid "Sync"
+msgstr ""
+
+msgid "Create missing translation entries"
+msgstr ""
+
+msgid "Create empty translation entries for {0} missing records?"
+msgstr ""
+
+msgid "Table Details"
+msgstr ""
+
+msgid "Tables with the \"auto\" field can track which translations were machine-translated. Add it via migration to enable this feature."
+msgstr ""
+
+msgid "EAV Strategy"
+msgstr ""
+
+msgid "Uses *_i18n tables with locale, model, foreign_key, field, content columns. More flexible but slower."
+msgstr ""
+
+msgid "ShadowTable Strategy"
+msgstr ""
+
+msgid "Uses *_translations tables with id, locale, and field columns directly. Better performance."
+msgstr ""
+
+msgid "Existing PO translations can be used as a glossary to suggest consistent translations for common terms."
+msgstr ""
+
+msgid "Record #{0}"
+msgstr ""
+
+msgid "Add Translation"
+msgstr ""
+
+msgid "Original"
+msgstr ""
+
+msgid "Mark as auto-translated"
+msgstr ""
+
+msgid "If checked, this translation is marked as machine-translated. It will be unchecked automatically when you manually edit the content."
+msgstr ""
+
+msgid "Save Translation"
+msgstr ""
+
+msgid "Base Record"
+msgstr ""
+
+msgid "Target Locale"
+msgstr ""
+
+msgid "Original Content"
+msgstr ""
+
+msgid "empty"
+msgstr ""
+
+msgid "Translation Entry"
+msgstr ""
+
+msgid "Model"
+msgstr ""
+
+msgid "Translation Type"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Source Record"
+msgstr ""
+
+msgid "Glossary Suggestions"
+msgstr ""
+
+msgid "Suggestions from existing PO translations"
+msgstr ""
+
+msgid "Quick Actions"
+msgstr ""
+
+msgid "Base Record Fields"
+msgstr ""
+
+msgid "Translations"
+msgstr ""
+
+msgid "Auto-translate All"
+msgstr ""
+
+msgid "Auto-translate this record to all configured locales?"
+msgstr ""
+
+msgid "Add"
+msgstr ""
+
+msgid "Auto-translate"
+msgstr ""
+
+msgid "Auto-translate to {0}?"
+msgstr ""
+
+msgid "Back to List"
+msgstr ""
+
+msgid "Overview"
+msgstr ""
+
+msgid "bestPractice"
+msgstr ""
+
+msgid "Common things"
+msgstr ""
+
+msgid "Always code in English (not only the code - all translation strings should be that way as well)"
+msgstr ""
+
+msgid "Use short terminology for sentences and longer translations - camelCased ideally: \"breadcrumpTrail\""
+msgstr ""
+
+msgid "Group them together by their meaning, like \"valErr...\" for Validation Errors, or \"textWhy..\" for some long text/explanation on the website"
+msgstr ""
+
+msgid "With these tips you can easily use the translate plugin to generate your translation base - and let translaters do their job."
+msgstr ""
+
+msgid "List Strings"
+msgstr ""
+
+msgid "Add String"
+msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "Total Controllers"
+msgstr ""
+
+msgid "Sources"
+msgstr ""
+
+msgid "Project Path"
+msgstr ""
+
+msgid "Scanning loaded plugins (no project path configured)."
+msgstr ""
+
+msgid "Usage"
+msgstr ""
+
+msgid "Use these singular and plural forms as translation strings for your controller names."
+msgstr ""
+
+msgid "Add them to your PO files or import them via the Strings page."
+msgstr ""
+
 msgid "Controller Names"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/extract.php:100
+msgid "No controllers found. Make sure the project path is configured correctly."
+msgstr ""
+
+msgid "controllers"
+msgstr ""
+
+msgid "Controller"
+msgstr ""
+
+msgid "Singular"
+msgstr ""
+
+msgid "Plural"
+msgstr ""
+
+msgid "Result"
+msgstr ""
+
+msgid "Convert text"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Run i18n Extract"
+msgstr ""
+
+msgid "Scanned Paths"
+msgstr ""
+
+msgid "Locale Paths"
+msgstr ""
+
+msgid "Detected Domains"
+msgstr ""
+
+msgid "domains"
+msgstr ""
+
+msgid "Scanned the project source for `__d(domain, ...)` calls. Each row shows whether an app-level PO file exists for that domain in each available locale."
+msgstr ""
+
+msgid "No `__d()` calls found in the scanned paths."
+msgstr ""
+
+msgid "Domain"
+msgstr ""
+
+msgid "msgids"
+msgstr ""
+
+msgid "Calls"
+msgstr ""
+
+msgid "Files"
+msgstr ""
+
+msgid "POT"
+msgstr ""
+
+msgid "Suggestion"
+msgstr ""
+
+msgid "CakePHP default domain — typically translated via the app default.po"
+msgstr ""
+
+msgid "No app-level POT file"
+msgstr ""
+
+msgid "Missing app-level {0}.po — falls back to default domain"
+msgstr ""
+
+msgid "Use the regular i18n extract for the default domain."
+msgstr ""
+
+msgid "Stage 1: Extract"
+msgstr ""
+
+msgid "No POT yet — run i18n extract to generate it."
+msgstr ""
+
+msgid "Stage 2: Import"
+msgstr ""
+
+msgid "POT exists but no strings imported — load it into the DB."
+msgstr ""
+
+msgid "Import {0}.pot"
+msgstr ""
+
+msgid "Stage 3: Dump"
+msgstr ""
+
+msgid "{0} string(s) in DB but no app-level {1}.po — dump to filesystem so the app can load it."
+msgstr ""
+
+msgid "Dump translations"
+msgstr ""
+
+msgid "Covered"
+msgstr ""
+
+msgid "{0} string(s) in DB, default-locale .po present."
+msgstr ""
+
+msgid "Default-locale .po present (managed outside the DB workflow)."
+msgstr ""
+
+msgid "Re-extract"
+msgstr ""
+
+msgid "Used in"
+msgstr ""
+
+msgid "more"
+msgstr ""
+
+msgid "Sample msgids"
+msgstr ""
+
+msgid "Edit Project"
+msgstr ""
+
+msgid "All Projects"
+msgstr ""
+
+msgid "Start Translating"
+msgstr ""
+
+msgid "No project selected"
+msgstr ""
+
+msgid "Create"
+msgstr ""
+
+msgid "Domains"
+msgstr ""
+
+msgid "Strings"
+msgstr ""
+
+msgid "Terms"
+msgstr ""
+
+msgid "Overall Coverage"
+msgstr ""
+
+msgid "Coverage by Language"
+msgstr ""
+
+msgid "Translation Quality"
+msgstr ""
+
+msgid "Batch Confirm"
+msgstr ""
+
+msgid "Confirmed"
+msgstr ""
+
+msgid "Unconfirmed"
+msgstr ""
+
+msgid "Progress"
+msgstr ""
+
+msgid "Confirmed translations have been reviewed and approved for production use."
+msgstr ""
+
+msgid "Recent Strings"
+msgstr ""
+
+msgid "View Details"
+msgstr ""
+
+msgid "String Details"
+msgstr ""
+
+msgid "String"
+msgstr ""
+
+msgid "Context"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Last Import"
+msgstr ""
+
+msgid "Flags"
+msgstr ""
+
+msgid "Recent Translations"
+msgstr ""
+
+msgid "View Translation"
+msgstr ""
+
+msgid "Translation Change"
+msgstr ""
+
+msgid "Changes from last edit"
+msgstr ""
+
+msgid "Unified Diff"
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Original String"
+msgstr ""
+
+msgid "Current Translation"
+msgstr ""
+
+msgid "Plural Translation"
+msgstr ""
+
+msgid "Comment"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "View String"
+msgstr ""
+
+msgid "Recently Imported Strings"
+msgstr ""
+
+msgid "Has plural form"
+msgstr ""
+
+msgid "Contains HTML"
+msgstr ""
+
+msgid "Audit Trail"
+msgstr ""
+
+msgid "Time"
+msgstr ""
+
+msgid "Source"
+msgstr ""
+
+msgid "Updated"
+msgstr ""
+
+msgid "Deleted"
+msgstr ""
+
+msgid "Audit Information"
+msgstr ""
+
+msgid "Timestamp"
+msgstr ""
+
+msgid "Transaction"
+msgstr ""
+
+msgid "Full Details"
+msgstr ""
+
+msgid "View in AuditStash"
+msgstr ""
+
+msgid "Changed Fields"
+msgstr ""
+
+msgid "Before"
+msgstr ""
+
+msgid "After"
+msgstr ""
+
+msgid "Created Data"
+msgstr ""
+
+msgid "Value"
+msgstr ""
+
+msgid "Available Features"
+msgstr ""
+
+msgid "Audit Logging"
+msgstr ""
+
+msgid "AuditStash Plugin"
+msgstr ""
+
+msgid "Plugin installed but disabled in config"
+msgstr ""
+
+msgid "Disabled"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "Not Installed"
+msgstr ""
+
+msgid "Advanced Search"
+msgstr ""
+
+msgid "FriendsOfCake/Search Plugin"
+msgstr ""
+
+msgid "Auto-Translation API"
+msgstr ""
+
+msgid "Google Translate, DeepL, etc."
+msgstr ""
+
+msgid "Available"
+msgstr ""
+
+msgid "Not Available"
+msgstr ""
+
+msgid "Detailed Statistics"
+msgstr ""
+
+msgid "Import from PO/POT files"
+msgstr ""
+
+msgid "Export to PO files"
+msgstr ""
+
+msgid "Import locales from filesystem"
+msgstr ""
+
+msgid "TranslateBehavior & Shadow Tables"
+msgstr ""
+
+msgid "Orphaned Strings"
+msgstr ""
+
+msgid "Best Practices"
+msgstr ""
+
+msgid "Reset Project Data"
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Selection"
+msgstr ""
+
+msgid "or"
+msgstr ""
+
+msgid "Hard reset Translate (fully truncate all tables)"
+msgstr ""
+
+msgid "Sure?"
+msgstr ""
+
+msgid "Grand Total"
+msgstr ""
+
+msgid "Translation Progress"
+msgstr ""
+
+msgid "strings"
+msgstr ""
+
+msgid "Confirmation Progress"
+msgstr ""
+
+msgid "confirmed"
+msgstr ""
+
+msgid "Progress by Locale"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "Untranslated"
+msgstr ""
+
+msgid "Confirmation"
+msgstr ""
+
+msgid "No active domains found. Please activate at least one domain to see statistics."
+msgstr ""
+
+msgid "No active locales found. Please add at least one locale to see statistics."
+msgstr ""
+
+msgid "List API Translations"
+msgstr ""
+
+msgid "Add API Translation"
+msgstr ""
+
+msgid "Key"
+msgstr ""
+
+msgid "From"
+msgstr ""
+
+msgid "To"
+msgstr ""
+
+msgid "Engine"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "Edit API Translation"
+msgstr ""
+
+msgid "New API Translation"
+msgstr ""
+
+msgid "API Translations"
+msgstr ""
+
+msgid "Delete API Translation"
+msgstr ""
+
+msgid "Generate TranslateBehavior Migration"
+msgstr ""
+
+msgid "Select a table to generate a shadow table migration for CakePHP TranslateBehavior."
+msgstr ""
+
+msgid "TranslateBehavior"
+msgstr ""
+
+msgid "Generate Migration"
+msgstr ""
+
+msgid "Generate Migration for Table: {0}"
+msgstr ""
+
+msgid "This will create a shadow table named"
+msgstr ""
+
+msgid "to store translations for the selected fields."
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "Translation Strategy"
+msgstr ""
+
+msgid "Shadow Table"
+msgstr ""
+
+msgid "EAV (Entity-Attribute-Value)"
+msgstr ""
+
+msgid "Creates columns for each field. Better performance, recommended."
+msgstr ""
+
+msgid "Flexible, stores each field translation as a row. More flexible but slower."
+msgstr ""
+
+msgid "Include \"auto\" field"
+msgstr ""
+
+msgid "Adds a boolean field to track which translations were machine-generated. Recommended for auto-translation workflows."
+msgstr ""
+
+msgid "Select Fields to Translate"
+msgstr ""
+
+msgid "No translatable fields found in this table."
+msgstr ""
+
+msgid "Deselect All"
+msgstr ""
+
+msgid "Next Steps"
+msgstr ""
+
+msgid "Copy the migration code"
+msgstr ""
+
+msgid "Save to"
+msgstr ""
+
+msgid "Run:"
+msgstr ""
+
+msgid "Add to your Table class:"
+msgstr ""
+
+msgid "Generated Migration Code"
+msgstr ""
+
+msgid "Copy to Clipboard"
+msgstr ""
+
+msgid "Save Migration File"
+msgstr ""
+
+msgid "Back to Overview"
+msgstr ""
+
+msgid "Configure and Generate"
+msgstr ""
+
+msgid "Select the fields you want to translate and click \"Generate Migration\"."
+msgstr ""
+
+msgid "Migration code copied to clipboard!"
+msgstr ""
+
+msgid "CakePHP TranslateBehavior Overview"
+msgstr ""
+
+msgid "Manage Entries"
+msgstr ""
+
+msgid "This page shows where CakePHP's built-in TranslateBehavior is used in your application and helps you add translation support to more tables."
+msgstr ""
+
+msgid "Shadow Tables"
+msgstr ""
+
+msgid "Models Using Behavior"
+msgstr ""
+
+msgid "Candidate Tables"
+msgstr ""
+
+msgid "Orphaned Shadow Tables"
+msgstr ""
+
+msgid "Models Using TranslateBehavior"
+msgstr ""
+
+msgid "Model Class"
+msgstr ""
+
+msgid "All fields"
+msgstr ""
+
+msgid "View Shadow Table"
+msgstr ""
+
+msgid "Existing Shadow Tables"
+msgstr ""
+
+msgid "Base Table"
+msgstr ""
+
+msgid "Orphaned"
+msgstr ""
+
+msgid "Tables That Could Use Translation"
+msgstr ""
+
+msgid "No shadow table yet"
+msgstr ""
+
+msgid "Translatable Fields"
+msgstr ""
+
+msgid "Field Count"
+msgstr ""
+
+msgid "About CakePHP TranslateBehavior"
+msgstr ""
+
+msgid "CakePHP's TranslateBehavior allows you to translate database fields by storing translations in shadow tables (e.g. articles_translations)."
+msgstr ""
+
+msgid "Translation Strategies"
+msgstr ""
+
+msgid "Stores each translated field as a separate row with columns: locale, field, content."
+msgstr ""
+
+msgid "CakePHP default. Creates separate columns for each translated field in *_translations tables. Better performance."
+msgstr ""
+
+msgid "Learn more:"
+msgstr ""
+
+msgid "CakePHP TranslateBehavior Documentation"
+msgstr ""
+
+msgid "Exists"
+msgstr ""
+
+msgid "Has TranslateBehavior"
+msgstr ""
+
+msgid "No TranslateBehavior"
+msgstr ""
+
+msgid "Entity-Attribute-Value"
+msgstr ""
+
+msgid "Table Schema"
+msgstr ""
+
+msgid "Column"
+msgstr ""
+
+msgid "Length"
+msgstr ""
+
+msgid "Null"
+msgstr ""
+
+msgid "Default"
+msgstr ""
+
+msgid "Translation Data"
+msgstr ""
+
+msgid "first 20 rows"
+msgstr ""
+
+msgid "How to Use"
+msgstr ""
+
+msgid "This table uses the EAV (Entity-Attribute-Value) strategy where:"
+msgstr ""
+
+msgid "The language/locale code (e.g., en_US, de_DE)"
+msgstr ""
+
+msgid "The model name"
+msgstr ""
+
+msgid "ID of the record in the base table"
+msgstr ""
+
+msgid "Name of the translated field"
+msgstr ""
+
+msgid "The translated value"
+msgstr ""
+
+msgid "This table uses the Shadow Table strategy where each translated field has its own column."
+msgstr ""
+
+msgid "Note"
+msgstr ""
+
+msgid "The model class exists but doesn't have the TranslateBehavior attached. Add it to your Table class:"
+msgstr ""
+
+msgid "List Translate Domains"
+msgstr ""
+
+msgid "Add Translate Domain"
+msgstr ""
+
+msgid "Edit Translate Domain"
+msgstr ""
+
+msgid "Information"
+msgstr ""
+
+msgid "POT Files"
+msgstr ""
+
+msgid "POT (Portable Object Template) files contain the source strings to be translated."
+msgstr ""
+
+msgid "PO Files"
+msgstr ""
+
+msgid "PO (Portable Object) files contain translations for a specific language."
+msgstr ""
+
+msgid "Source Code"
+msgstr ""
+
+msgid "Extract translation strings directly from your application source code."
+msgstr ""
+
+msgid "Extract Translation Strings"
+msgstr ""
+
+msgid "From POT File"
+msgstr ""
+
+msgid "From PO File"
+msgstr ""
+
+msgid "From Source Code"
+msgstr ""
+
+msgid "Extract from source code"
+msgstr ""
+
 msgid "Extract controller names"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/index.php:24
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:31
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:31
 msgid "New Translate Domain"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:31
 msgid "This wizard helps you set up default translation domains for your application."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:34
 msgid "Select the domains you want to create and submit the form."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:46
 msgid "Setup Default Translate Domains"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/setup.php:61
 msgid "already exists"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:21
 msgid "Delete Translate Domain"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:48
 msgid "Domain Details"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:53
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:33
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:54
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:108
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:236
 msgid "Name"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:57
 msgid "Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateDomains/view.php:72
 msgid "Prio"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/add.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:35
 msgid "List Locales"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/add.php:22
 msgid "Add Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/edit.php:28
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:14
 msgid "Edit Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:25
 msgid "Import Locales"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:44
 msgid "Language name"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/from_locale.php:34
 msgid "{0} locale found"
 msgid_plural "{0} locales found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:18
 msgid "From Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:19
 msgid "To Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/index.php:20
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:17
 msgid "New Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:25
 msgid "Export Locales"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/to_locale.php:34
 msgid "{0} locale"
 msgid_plural "{0} locales"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:15
 msgid "Delete Locale"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:29
 msgid "Language Relation"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateLocales/view.php:41
 msgid "Iso2"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:26
 msgid "List Translate Projects"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:30
 msgid "Add Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:62
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:77
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:75
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:248
 msgid "Path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:64
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:79
 msgid "e.g., plugins/MyPlugin or leave empty for default app path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:67
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:82
 msgid "Optional: Relative or absolute path for this project (e.g., plugins/MyPlugin). Leave empty to use default app path."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:75
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:90
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:60
 msgid "Default Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/add.php:81
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:96
 msgid "Set this as the default translation project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/edit.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:16
 msgid "Edit Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:24
 msgid "New Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/index.php:35
 msgid "Translate Projects"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:26
 msgid "Warning"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:30
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:33
 msgid "Resetting will permanently remove selected data from the translation project. Make sure you have backups before proceeding."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:45
 msgid "Reset Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:54
 msgid "Reset Options"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:62
 msgid "Select which data to remove from this project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:68
 msgid "Languages"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/reset.php:76
 msgid "Select languages (only relevant for resetting terms)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:21
 msgid "Delete Translate Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:43
 msgid "Project Details"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:80
 msgid "Default app path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:100
 msgid "Related Translate Domains"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateProjects/view.php:110
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:244
 msgid "Priority"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:15
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:16
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:20
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:34
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:31
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:25
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:34
 msgid "List Translate Strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:25
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:30
 msgid "Field Information"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:28
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:109
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:33
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:114
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:86
 msgid "Is HTML"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:30
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:35
 msgid "Check this if the string contains HTML tags. When enabled, translations will not be automatically escaped, allowing HTML markup."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:31
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:36
 msgid "Use with caution!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:34
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:39
 msgid "Placeholders"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:36
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:41
 msgid "Use {0}, {1}, {2} etc. for dynamic values. Example: \"You have {0} items\" becomes \"You have 5 items\""
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:44
 msgid "Context Usage"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:41
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:46
 msgid "Context helps differentiate identical strings with different meanings:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:44
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:49
 msgid "verb"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:44
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:49
 msgid "noun"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:50
 msgid "button"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:50
 msgid "menu item"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:57
 msgid "Add Translate String"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:70
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:75
 msgid "The translation domain this string belongs to (e.g., \"default\", \"validation\")"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:76
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:81
 msgid "Name (Singular)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:81
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:86
 msgid "The source string to be translated. Use {0}, {1} for placeholders."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:92
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:97
 msgid "Optional plural form (e.g., \"One item\" → \"Multiple items\"). Must use same placeholders as singular."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:100
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:105
 msgid "e.g., \"navigation\", \"button\", \"error message\""
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:103
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:108
 msgid "Optional context to differentiate identical strings with different meanings (e.g., \"Post\" as noun vs verb)."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/add.php:115
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:129
 msgid "Translate Afterwards"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:12
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:17
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:30
 msgid "Analyze PO File"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:19
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:21
-msgid "Back"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:22
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:24
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:195
 msgid "Extract/Import"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:27
 msgid "Quick Analyze"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:41
 msgid "PO File Analyzer"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:46
 msgid "Analyzing: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:49
 msgid "Select a file from the sidebar, or paste/upload content below."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:53
 msgid "Input"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:59
 msgid "Select from Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:61
 msgid "Select a file"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:67
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:80
 msgid "- OR -"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:74
 msgid "Upload PO/POT File"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:86
 msgid "Paste PO Content"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:102
 msgid "Translation Style"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:104
 msgid "Auto-detect"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:105
 msgid "Text-based (msgid is readable text)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:106
 msgid "Key-based (msgid is a key like \"user.profile.title\")"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:113
 msgid "Auto-detect:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:114
 msgid "If msgid has no spaces and matches key patterns (foo.bar.baz, foo_bar_baz, fooBarBaz), HTML/whitespace checks are skipped."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:116
 msgid "Key-based:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:117
 msgid "Use this when msgid is a translation key, not actual text. Skips HTML/whitespace mismatch checks."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:121
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:27
 msgid "Analyze"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:128
 msgid "Analysis Results"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:133
 msgid "Statistics"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:138
 msgid "Total Strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:142
-#: ./vendor/dereuromark/cakephp-translate/templates/element/coverage_table.php:10
-msgid "Translated"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:146
-msgid "Untranslated"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:152
 msgid "Fuzzy"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:156
 msgid "Plurals"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:160
 msgid "With Context"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:172
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:47
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:141
 msgid "translated"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:186
-#: ./vendor/dereuromark/cakephp-translate/templates/element/suggestions.php:22
 msgid "Suggestions"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:202
 msgid "Issues Found"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:209
 msgid "String (msgid)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:210
 msgid "Issue"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:221
 msgid "Plural:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:224
 msgid "Translation:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:242
 msgid "Expected:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:244
 msgid "Actual:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:248
 msgid "Suggested fix for msgid:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:251
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:260
-msgid "Copy to clipboard"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:252
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:261
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:292
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:305
 msgid "Copy"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:257
 msgid "Suggested fix for msgstr:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:274
 msgid "No issues found!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:275
 msgid "Your PO file looks good."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:288
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/analyze.php:303
 msgid "Copied!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:21
 msgid "Debug Mode - Source Code Editing Enabled"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:24
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:41
 msgid "Warning:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:25
 msgid "You are about to edit the source code file directly. Make sure you have a clean working directory!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:28
 msgid "Show Source Code Editor"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:47
 msgid "Save Changes"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:51
 msgid "Remember to commit your changes!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/display_reference.php:61
 msgid "Code Excerpt"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:23
 msgid "Dump Translations"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:28
 msgid "Files are stored in:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:34
 msgid "Languages and Domains"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/dump.php:39
 msgid "No active domains found. Please activate them if they already exist."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:62
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:21
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:19
 msgid "Edit Translate String"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:120
 msgid "Update Code References"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/edit.php:123
 msgid "Update all occurrences in source files to match the new string"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:18
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:35
-msgid "Run i18n Extract"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:26
 msgid "Extract Translations"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/extract.php:31
 msgid "Locale Path:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:25
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:39
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:36
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:30
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:39
+msgid "Pre-selected the {0} domain (linked from Detected Domains analyzer)."
+msgstr ""
+
 msgid "New Translate String"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:47
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:73
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:52
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:68
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:88
-msgid "Filter"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:54
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:59
 msgid "noLimitation"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:57
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:62
-msgid "Search..."
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:57
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:62
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:28
-msgid "Search"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:62
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:78
 msgid "Missing Translation"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/index.php:69
 msgid "Please note that name/context are case sensitive by default!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:15
+msgid "Status:"
+msgstr ""
+
+msgid "Pending review"
+msgstr ""
+
+msgid "All Strings"
+msgstr ""
+
+msgid "Info"
+msgstr ""
+
+msgid "Orphaned strings are translation strings that no longer have references to source code files. This usually means the original code was removed or refactored."
+msgstr ""
+
+msgid "You can safely delete these strings if they are no longer needed, or keep them if they were manually added."
+msgstr ""
+
+msgid "Actions apply to all {0} orphaned strings"
+msgstr ""
+
+msgid "Mark All Inactive"
+msgstr ""
+
+msgid "Mark all {0} orphaned strings as inactive?"
+msgstr ""
+
+msgid "Delete All"
+msgstr ""
+
+msgid "Are you sure you want to delete all {0} orphaned strings? This cannot be undone."
+msgstr ""
+
+msgid "No orphaned strings found"
+msgstr ""
+
+msgid "All translation strings have references to source code."
+msgstr ""
+
 msgid "Run i18n Extract (Experimental)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:36
 msgid "Experimental"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:42
 msgid "This runs the CakePHP i18n extract command. It will scan your source files and generate/update POT files. Make sure you have a backup of your locale files."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:48
 msgid "Plugin domain: <strong>{0}.pot</strong> (only this file will be kept, others like default.pot will be removed)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:54
 msgid "Project Paths"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:58
 msgid "App Path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:61
 msgid "Locale Path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:69
 msgid "Extraction Options"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:73
 msgid "Paths to scan (one per line)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:76
 msgid "Leave empty to use defaults: src/ and templates/"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:81
 msgid "Output Path"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:83
 msgid "Where to write the POT files"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:90
 msgid "Dry run (preview only)"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:97
 msgid "Merge with existing"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:104
 msgid "Overwrite existing"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:114
 msgid "Extract core strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:125
 msgid "Import directly to database"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:128
 msgid "When checked, the extracted strings will be imported directly into the database after extraction."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:133
 msgid "Run Extract"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:141
 msgid "Results"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:145
 msgid "Command Executed"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:155
 msgid "Output"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:157
 msgid "Exit code: {0}"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:169
 msgid "Dry Run Preview"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:172
 msgid "The following POT files would be generated:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:178
 msgid "{0} strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:188
 msgid "This was a dry run. Uncheck \"Dry run\" and submit again to actually write the files."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/run_extract.php:195
 msgid "POT files have been generated. You can now import them via the {0} page."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:29
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:62
 msgid "Translate String"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:36
 msgid "String:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:46
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:54
 msgid "HTML"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:46
 msgid "Manual escaping necessary!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:60
 msgid "Required placeholders:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:71
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:89
 msgid "Translate This String"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:78
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:98
-msgid "Singular"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:104
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:105
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:129
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:130
-msgid "Save"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:105
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:130
-#: ./vendor/dereuromark/cakephp-translate/templates/element/pagination.php:26
 msgid "Next"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:106
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:131
 msgid "Skip"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:116
 msgid "Additional Information"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:131
 msgid "Domain:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:136
 msgid "References:"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:162
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:286
 msgid "Code Reference"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/translate.php:168
 msgid "Close"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:54
 msgid "Translate String Details"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:66
 msgid "User"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:122
 msgid "Language"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:123
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:93
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:88
-msgid "Translation"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:140
 msgid "Using default value"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:145
-msgid "Not translated"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:156
 msgid "Pending"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:168
 msgid "No translations available yet."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:169
 msgid "Translate now"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:193
 msgid "Code References"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:228
 msgid "Domain Information"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:264
 msgid "View Domain"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:269
 msgid "Edit Domain"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateStrings/view.php:293
 msgid "Loading..."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:26
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:29
 msgid "List Translate Terms"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/edit.php:47
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:19
 msgid "Edit Translate Term"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/index.php:92
 msgid "Text"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:12
 msgid "Pending Translations"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:29
 msgid "pending translations"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:33
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:56
 msgid "Confirm All"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:49
 msgid "All Locales"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:52
 msgid "total pending"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:61
 msgid "Are you sure you want to confirm all pending translations?"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:76
 msgid "Pending Translations List"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:78
 msgid "{{count}} pending"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:98
 msgid "No pending translations!"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:152
 msgid "Confirm"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:164
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:196
 msgid "first"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:165
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:197
 msgid "previous"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:167
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:199
 msgid "next"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:168
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:200
 msgid "last"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/pending.php:171
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:203
-#: ./vendor/dereuromark/cakephp-translate/templates/element/pagination.php:29
 msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:24
 msgid "Delete Translate Term"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:56
 msgid "Translate Term Details"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:88
 msgid "User Id"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:96
 msgid "Confirmed By"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Admin/TranslateTerms/view.php:115
-msgid "Content"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:18
 msgid "Translate Plugin"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:21
 msgid "Easily manage i18n/translations from your backend."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:42
 msgid "Current Translation Coverage"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:121
 msgid "Quick Start"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:128
 msgid "Select Domain"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:160
 msgid "Start Translating Next"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/index.php:165
 msgid "Browse All Terms"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:13
 msgid "Translation Terms"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:21
 msgid "Filters"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:29
 msgid "Search in strings..."
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:37
 msgid "All domains"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:43
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:120
 msgid "Skipped"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:45
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:56
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:67
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:80
-#: ./vendor/dereuromark/cakephp-translate/templates/element/yes_no.php:23
 msgid "Yes"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:46
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:57
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:68
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:81
-#: ./vendor/dereuromark/cakephp-translate/templates/element/yes_no.php:27
 msgid "No"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:48
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:59
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:70
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:83
 msgid "All"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:65
 msgid "Has Plural"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:108
 msgid "Translation Strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:110
 msgid "{{count}} strings"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/terms.php:171
 msgid "None"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:45
-msgid "strings"
-msgstr ""
-
-#: ./vendor/dereuromark/cakephp-translate/templates/Translate/translate.php:58
 msgid "complete"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/coverage_table.php:10
 msgid "Coverage"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/pagination.php:17
 msgid "First"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/pagination.php:20
 msgid "Last"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/pagination.php:23
 msgid "Previous"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/project_switch.php:25
 msgid "Project"
 msgstr ""
 
-#: ./vendor/dereuromark/cakephp-translate/templates/element/project_switch.php:35
 msgid "pleaseSelect"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- Re-extract `resources/locales/translate.pot` from the current `src/` and `templates/`. The committed POT was ~199 msgids out of date — strings added in newer code had no entry, so translators couldn't translate them.
- Drop the per-string `#: ./vendor/dereuromark/cakephp-translate/...` location comments from the previous POT. Those vendor-rooted paths leaked in from running the extract inside a host app's `vendor/` folder rather than from the plugin root; switching to `--no-location` keeps future regenerations clean (a single line move no longer reshuffles every entry).

No code changes — the plugin already uses `__d('translate', ...)` consistently throughout `src/` and `templates/` (1331 calls, single domain). The POT was just stale.

## Why

The 199 missing strings include all the locale-management UI added in recent releases (`Invalid translation table name.`, `Translation saved successfully.`, the bulk-translate progress messages, etc.), so a German/Japanese/etc. language pack derived from the old POT would have a sea of untranslated strings in those screens.

## Verification (local)

- phpunit: 179 / 179 (5 pre-existing skipped, unrelated)
- phpstan: 1 pre-existing error in `DomainScannerService::scan` return type — not introduced by this change (the diff is locale-only)
- phpcs: clean