### PR TITLE
Re-enable TLS verification on Google and Transltr engines

### DIFF
--- a/src/Translator/Engine/GoogleTranslate.php
+++ b/src/Translator/Engine/GoogleTranslate.php
@@ -83,8 +83,6 @@ class GoogleTranslate {
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $fieldsString);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_ENCODING, 'UTF-8');
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'AndroidTranslate/5.3.0.RC02.130475354-53000263 5.1 phone TRANSLATE_OPM5_TEST_1');
 		// Execute post
 		$result = curl_exec($ch);

--- a/src/Translator/Engine/Transltr.php
+++ b/src/Translator/Engine/Transltr.php
@@ -12,7 +12,7 @@ class Transltr implements EngineInterface {
 	/**
 	 * @var string
 	 */
-	public const URL = 'http://transltr.org/api/translate?text=%s&to=%s&from=%s';
+	public const URL = 'https://transltr.org/api/translate?text=%s&to=%s&from=%s';
 
 	/**
 	 * @param string $text Text
@@ -31,7 +31,6 @@ class Transltr implements EngineInterface {
 			curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
 
 			curl_setopt($handler, CURLOPT_URL, $url);
-			curl_setopt($handler, CURLOPT_SSL_VERIFYPEER, false);
 
 			/** @var string|false $remoteResult */
 			$remoteResult = curl_exec($handler);


### PR DESCRIPTION
## Summary

Both translation engines disabled certificate validation. On `GoogleTranslate` the override was a full bypass — `CURLOPT_SSL_VERIFYPEER=false` AND `CURLOPT_SSL_VERIFYHOST=0`, which accepts *any* certificate from *any* peer, not just a self-signed one for the expected host. On `Transltr`, the URL was plain `http://` to begin with, with the verify flag set defensively in case it ever moved to HTTPS.

A network attacker between the app and translate.googleapis.com / transltr.org could substitute responses; the translated strings then end up in the application's translation memory and ship to end users (or to localization files committed to the repo).

The merged review flagged both — TLS-disabled engines were the top source-grounded bug for the plugin. The per-plugin security re-analysis tagged this as Issue #4.

## Fix

- Drop the `CURLOPT_SSL_VERIFY*` overrides on `GoogleTranslate`; modern PHP+OpenSSL handle Google's cert chain out of the box.
- Switch `Transltr`'s URL constant to `https://`; drop its `CURLOPT_SSL_VERIFYPEER=false` override. If the upstream still doesn't serve TLS reliably, the engine fails closed (returns null with the existing exception path) instead of accepting an unauthenticated response.

## Tests

Existing 179 tests pass. No test exercises the live HTTP path (engines are mocked or skipped without network), so this PR adds no new tests. phpcs and phpstan are clean.