### PR TITLE
Honor configured model and accept project id in DbMessagesLoader

### DIFF
--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -46,24 +46,37 @@ class DbMessagesLoader {
 	protected string $formatter;
 
 	/**
+	 * Optional project id to load translations from. When null, the loader
+	 * resolves to the default TYPE_APP project (backwards-compatible default).
+	 *
+	 * @var int|null
+	 */
+	protected ?int $projectId;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $domain Domain name.
 	 * @param string $locale Locale string.
 	 * @param \Cake\Datasource\RepositoryInterface|string|null $model Model name or instance.
-	 *   Defaults to 'I18nMessages'.
+	 *   Defaults to 'Translate.TranslateTerms'.
 	 * @param string $formatter Formatter name. Defaults to 'default' (ICU formatter).
+	 * @param int|null $projectId Optional project id. When null, the default
+	 *   TYPE_APP project is used. Use this in multi-project setups to load
+	 *   translations from a non-default project.
 	 */
 	public function __construct(
 		string $domain,
 		string $locale,
 		string|RepositoryInterface|null $model = null,
 		string $formatter = 'default',
+		?int $projectId = null,
 	) {
 		$this->domain = $domain;
 		$this->locale = $locale;
 		$this->model = $model ?: 'Translate.TranslateTerms';
 		$this->formatter = $formatter;
+		$this->projectId = $projectId;
 	}
 
 	/**
@@ -73,21 +86,17 @@ class DbMessagesLoader {
 	 * @return \Cake\I18n\Package
 	 */
 	public function __invoke(): Package {
-		$model = $this->fetchTable('Translate.TranslateTerms');
+		/** @var \Cake\ORM\Table $model */
+		$model = $this->_getModel();
 
-		$translateProject = $this->fetchTable('Translate.TranslateProjects')
-			->find()
-			->where(['type' => TranslateProject::TYPE_APP, 'default' => true])
-			->first();
-		if (!$translateProject) {
+		$translateProjectId = $this->projectId ?? $this->_resolveDefaultProjectId();
+		if ($translateProjectId === null) {
 			return new Package($this->formatter);
 		}
 
-		$translateProjectId = $translateProject->id;
 		$query = $model->find();
 
 		// Get list of fields without primaryKey, domain, locale.
-		/** @var \Cake\Database\Schema\TableSchema $schema */
 		$schema = $model->getSchema();
 		$fields = $schema->columns();
 		$fields = array_flip(array_diff(
@@ -181,6 +190,21 @@ class DbMessagesLoader {
 
 		/** @var \Translate\Model\Table\TranslateTermsTable */
 		return $this->model;
+	}
+
+	/**
+	 * Resolve the default TYPE_APP project id when no explicit project was
+	 * passed to the constructor. Mirrors the pre-multi-project behavior.
+	 *
+	 * @return int|null
+	 */
+	protected function _resolveDefaultProjectId(): ?int {
+		$translateProject = $this->fetchTable('Translate.TranslateProjects')
+			->find()
+			->where(['type' => TranslateProject::TYPE_APP, 'default' => true])
+			->first();
+
+		return $translateProject ? (int)$translateProject->id : null;
 	}
 
 }

--- a/tests/TestCase/I18n/DbMessagesLoaderTest.php
+++ b/tests/TestCase/I18n/DbMessagesLoaderTest.php
@@ -7,6 +7,7 @@ use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Translate\Filesystem\Folder;
 use Translate\I18n\DbMessagesLoader;
+use Translate\Model\Entity\TranslateProject;
 
 class DbMessagesLoaderTest extends TestCase {
 
@@ -74,6 +75,73 @@ class DbMessagesLoaderTest extends TestCase {
 
 		$translated = __xn('MyContext', 'Sing', 'Plur', 2);
 		$this->assertSame('MyPlurTrans', $translated);
+	}
+
+	/**
+	 * Regression: multi-project setups can target a non-default project by
+	 * passing the project id to the constructor. Before this change the
+	 * loader hard-coded "default TYPE_APP project" via internal lookup, so
+	 * translations on non-default projects were unreachable.
+	 *
+	 * @return void
+	 */
+	public function testHonorsExplicitProjectId() {
+		// I18n caches materialized translators across config() reconfigurations
+		// unless the cache is explicitly cleared between tests.
+		I18n::clear();
+
+		$projects = $this->fetchTable('Translate.TranslateProjects');
+		$secondProject = $projects->newEntity([
+			'name' => 'Second',
+			'type' => TranslateProject::TYPE_APP,
+			'default' => false,
+			'active' => true,
+		]);
+		$projects->saveOrFail($secondProject);
+
+		/** @var \Translate\Model\Table\TranslateStringsTable $TranslateStrings */
+		$TranslateStrings = $this->fetchTable('Translate.TranslateStrings');
+		$secondDomain = $TranslateStrings->TranslateDomains->newEntity([
+			'translate_project_id' => $secondProject->id,
+			'name' => 'default',
+			'active' => true,
+		]);
+		$TranslateStrings->TranslateDomains->saveOrFail($secondDomain);
+
+		$secondLocale = $TranslateStrings->TranslateTerms->TranslateLocales->init(
+			'DE',
+			'de',
+			'de',
+			(int)$secondProject->id,
+		);
+
+		$secondString = $TranslateStrings->import(
+			['name' => 'Sing', 'content' => 'SecondProjectTrans'],
+			$secondDomain->id,
+		);
+		$TranslateStrings->TranslateTerms->import(
+			['name' => 'Sing', 'content' => 'SecondProjectTrans'],
+			$secondString->id,
+			$secondLocale->id,
+		);
+
+		$secondProjectId = (int)$secondProject->id;
+
+		// Sanity check the fixture/setup actually produced a second-project term.
+		$terms = $this->fetchTable('Translate.TranslateTerms');
+		$secondTerm = $terms->find()
+			->contain(['TranslateStrings' => 'TranslateDomains', 'TranslateLocales'])
+			->where(['TranslateLocales.translate_project_id' => $secondProjectId])
+			->first();
+		$this->assertNotNull($secondTerm, 'setup precondition: second-project term must exist');
+		$this->assertSame('SecondProjectTrans', $secondTerm->content);
+
+		// Invoke the loader directly to confirm project-id filtering works.
+		$loader = new DbMessagesLoader('default', 'de', null, 'default', $secondProjectId);
+		$package = $loader();
+		$messages = $package->getMessages();
+		$this->assertArrayHasKey('Sing', $messages);
+		$this->assertSame('SecondProjectTrans', $messages['Sing']['_context']['']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`DbMessagesLoader::__invoke()` had two hard-coded lookups that broke its own contract.

### 1. The configured model was ignored

The constructor stored `$this->model` (defaulting to `'Translate.TranslateTerms'`, but overridable). `__invoke()` then hard-coded `$model = $this->fetchTable('Translate.TranslateTerms')` — the configured model never reached the query. The lazy `_getModel()` resolver was already in the class but unused.

### 2. Multi-project setups silently collapsed to one project

`__invoke()` queried the `TranslateProjects` table for the single TYPE_APP project with `default = true` and used that id for every translation lookup. The plugin's advertised multi-project support meant nothing through this loader — translations on any non-default project were unreachable.

## Fix

- `__invoke()` now calls `_getModel()` so the configured model wins.
- New optional `?int $projectId` constructor parameter (last, default null). When null, the loader resolves the default TYPE_APP project as before — fully backwards compatible. When set, that project id is used directly.
- Extracted the default-project resolution into `_resolveDefaultProjectId()` for readability.

Matches the merged review's strategic bug #2 for this plugin.

## Tests

- New `testHonorsExplicitProjectId` — creates a second TYPE_APP project (non-default) with its own domain, locale, and translation; instantiates the loader directly with that project's id; asserts the resulting Package contains the second project's translation, not the first.
- The existing `testDefault` and `testDomain` continue to pass (default-project path is behavior-preserving).

All 180 tests pass; phpcs and phpstan are clean.