### PR TITLE
Walk locale fallback chain in DbMessagesLoader

### DIFF
--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -94,6 +94,11 @@ class DbMessagesLoader {
 			return new Package($this->formatter);
 		}
 
+		$localeChain = $this->_resolveLocaleFallbackChain($this->locale);
+		if ($localeChain === []) {
+			return new Package($this->formatter);
+		}
+
 		$query = $model->find();
 
 		// Get list of fields without primaryKey, domain, locale.
@@ -107,31 +112,72 @@ class DbMessagesLoader {
 		$query->select(array_flip($fields));
 
 		$query->contain(['TranslateStrings' => 'TranslateDomains', 'TranslateLocales']);
-		$query->select(['TranslateStrings.name', 'TranslateStrings.plural', 'TranslateStrings.context']);
+		$query->select([
+			'TranslateStrings.name',
+			'TranslateStrings.plural',
+			'TranslateStrings.context',
+			'TranslateLocales.locale',
+		]);
 
 		$results = $query
 			->where(['TranslateDomains.translate_project_id' => $translateProjectId])
 			->where(['TranslateLocales.translate_project_id' => $translateProjectId])
-			->where(['TranslateDomains.name' => $this->domain, 'TranslateLocales.locale' => $this->locale])
+			->where(['TranslateDomains.name' => $this->domain])
+			->where(['TranslateLocales.locale IN' => $localeChain])
 			->where(['TranslateStrings.active' => true])
 			->enableHydration(false)
 			->all();
 
-		return new Package($this->formatter, null, $this->_messages($results));
+		return new Package($this->formatter, null, $this->_messages($results, $localeChain));
 	}
 
 	/**
-	 * Converts DB resultset to messages array.
+	 * Build the locale lookup chain. A request for `de_AT` falls back to
+	 * `de` (and finally to the source string via Cake's translator)
+	 * exactly the way `MessagesFileLoader` walks `.po` files. Locales
+	 * without a region (`de`, `en`) chain to themselves only.
+	 *
+	 * @param string $locale Requested locale (e.g. `de_AT`, `fr_CA`, `en`).
+	 *
+	 * @return list<string> Locales in priority order — most specific first.
+	 */
+	protected function _resolveLocaleFallbackChain(string $locale): array {
+		if ($locale === '') {
+			return [];
+		}
+
+		$chain = [$locale];
+		$sepPos = strpos($locale, '_');
+		if ($sepPos !== false) {
+			$parent = substr($locale, 0, $sepPos);
+			if ($parent !== '' && $parent !== $locale) {
+				$chain[] = $parent;
+			}
+		}
+
+		return $chain;
+	}
+
+	/**
+	 * Converts the DB resultset to a messages array, honoring the
+	 * locale fallback chain (most-specific locale wins).
+	 *
+	 * The query may return rows from multiple locales (`de_AT` + `de`
+	 * when the caller asked for `de_AT`). Rows are partitioned by
+	 * locale and the chain is walked in priority order: the first
+	 * locale to provide an entry for a given (singular, context) pair
+	 * wins, subsequent locales fill remaining gaps.
 	 *
 	 * @param \Cake\Datasource\ResultSetInterface $results ResultSet instance.
+	 * @param list<string> $localeChain Locales in priority order.
+	 *
 	 * @return array
 	 */
-	protected function _messages(ResultSetInterface $results): array {
+	protected function _messages(ResultSetInterface $results, array $localeChain): array {
 		if (!$results->count()) {
 			return [];
 		}
 
-		$messages = [];
 		$pluralForms = 0;
 		$item = $results->first();
 		// There are max 6 plural forms possible but most people won't need
@@ -144,32 +190,45 @@ class DbMessagesLoader {
 			}
 		}
 
-		foreach ($results as $item) {
-			$singular = $item['translate_string']['name'];
-			$context = $item['translate_string']['context'];
-			$translation = $item['content'];
-			if ($context) {
-				$messages[$singular]['_context'][$context] = $translation;
-			} else {
-				$messages[$singular]['_context'][''] = $translation;
-			}
-
-			if ($item['translate_string']['plural'] === null) {
+		/** @var array<string, list<array<string, mixed>>> $byLocale */
+		$byLocale = [];
+		foreach ($results as $row) {
+			$locale = $row['translate_locale']['locale'] ?? '';
+			if (!is_string($locale) || $locale === '') {
 				continue;
 			}
+			$byLocale[$locale][] = $row;
+		}
 
-			$key = $item['translate_string']['plural'];
-			$plurals = [
-				$translation,
-			];
-			for ($i = 1; $i <= $pluralForms; $i++) {
-				$plurals[] = $item['plural_' . ($i + 1)];
+		$messages = [];
+		foreach ($localeChain as $locale) {
+			if (!isset($byLocale[$locale])) {
+				continue;
 			}
+			foreach ($byLocale[$locale] as $row) {
+				$singular = $row['translate_string']['name'];
+				$context = (string)($row['translate_string']['context'] ?? '');
+				$translation = $row['content'];
 
-			if ($context) {
-				$messages[$key]['_context'][$context] = $plurals;
-			} else {
-				$messages[$key]['_context'][''] = $plurals;
+				// First (most-specific) locale to provide this key wins.
+				if (!isset($messages[$singular]['_context'][$context])) {
+					$messages[$singular]['_context'][$context] = $translation;
+				}
+
+				if ($row['translate_string']['plural'] === null) {
+					continue;
+				}
+
+				$pluralKey = $row['translate_string']['plural'];
+				if (isset($messages[$pluralKey]['_context'][$context])) {
+					continue;
+				}
+
+				$plurals = [$translation];
+				for ($i = 1; $i <= $pluralForms; $i++) {
+					$plurals[] = $row['plural_' . ($i + 1)];
+				}
+				$messages[$pluralKey]['_context'][$context] = $plurals;
 			}
 		}
 

--- a/tests/TestCase/I18n/DbMessagesLoaderTest.php
+++ b/tests/TestCase/I18n/DbMessagesLoaderTest.php
@@ -145,6 +145,73 @@ class DbMessagesLoaderTest extends TestCase {
 	}
 
 	/**
+	 * Regression for the locale-fallback chain: when a request for the
+	 * regional locale `de_AT` finds no entry, the loader must fall back
+	 * to the parent locale `de`. Mirrors the way Cake's
+	 * `MessagesFileLoader` walks `de_AT.po` -> `de.po` -> default.
+	 *
+	 * @return void
+	 */
+	public function testFallsBackToParentLocale(): void {
+		/** @var \Translate\Model\Table\TranslateStringsTable $TranslateStrings */
+		$TranslateStrings = $this->fetchTable('Translate.TranslateStrings');
+
+		// `de` is already set up by _setUpData() with Sing -> SingTrans.
+		// `de_AT` exists but has no translations for the test keys, so
+		// the lookup MUST fall back to `de`.
+		$TranslateStrings->TranslateTerms->TranslateLocales->init('DE-AT', 'de_AT', 'at', 1);
+
+		$loader = new DbMessagesLoader('default', 'de_AT');
+		$messages = $loader()->getMessages();
+
+		$this->assertArrayHasKey('Sing', $messages);
+		$this->assertSame('SingTrans', $messages['Sing']['_context'][''], 'de_AT must fall back to de.');
+	}
+
+	/**
+	 * The more-specific locale must win when both have an entry — the
+	 * fallback is for gaps, not for shadowing local overrides.
+	 *
+	 * @return void
+	 */
+	public function testRegionalLocaleOverridesParentWhenPresent(): void {
+		/** @var \Translate\Model\Table\TranslateStringsTable $TranslateStrings */
+		$TranslateStrings = $this->fetchTable('Translate.TranslateStrings');
+		$deAt = $TranslateStrings->TranslateTerms->TranslateLocales->init('DE-AT', 'de_AT', 'at', 1);
+		$default = $TranslateStrings->TranslateDomains->getDomain(1);
+
+		// `Sing` is already `SingTrans` in `de` per _setUpData().
+		// Add an Austrian override.
+		$existing = $TranslateStrings->find()
+			->where(['name' => 'Sing', 'translate_domain_id' => $default->id])
+			->firstOrFail();
+		$TranslateStrings->TranslateTerms->import(
+			['name' => 'Sing', 'content' => 'SingAustrian'],
+			$existing->id,
+			$deAt->id,
+		);
+
+		$loader = new DbMessagesLoader('default', 'de_AT');
+		$messages = $loader()->getMessages();
+
+		$this->assertSame('SingAustrian', $messages['Sing']['_context'][''], 'Regional locale must shadow its parent.');
+	}
+
+	/**
+	 * Non-regional locales (no underscore) chain to themselves only —
+	 * verify nothing weird happens like a query against an empty parent.
+	 *
+	 * @return void
+	 */
+	public function testNonRegionalLocaleChainsToSelfOnly(): void {
+		$loader = new DbMessagesLoader('default', 'de');
+		$messages = $loader()->getMessages();
+
+		$this->assertArrayHasKey('Sing', $messages);
+		$this->assertSame('SingTrans', $messages['Sing']['_context']['']);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testDomain() {


### PR DESCRIPTION
## Summary

A request for `de_AT` previously queried the database for that exact locale string only. If the regional locale was empty — the common case, since most apps translate at the language level and only sprinkle region overrides — the loader returned an empty `Package` and Cake's translator fell straight through to the source English string.

The file-based loader Cake itself ships chains `de_AT.po` → `de.po`, so the DB loader was a quiet behavior surprise for any multi-locale app.

## Fix

This adds the same chain:

- `_resolveLocaleFallbackChain($locale)` derives the lookup order. `de_AT` → `['de_AT', 'de']`. Non-regional locales (no `_`) chain to themselves only.
- The query now uses `WHERE TranslateLocales.locale IN ($chain)` with `TranslateLocales.locale` included in the SELECT so rows can be grouped per-locale on the PHP side.
- `_messages()` walks the chain in priority order. The first locale to provide a `(name, context)` pair wins; subsequent locales fill remaining gaps. That gives correct semantics for the two cases that matter:
  - missing-in-region → falls back to parent,
  - present-in-region → shadows the parent.

The protected `_messages()` signature gains a `list<string> $localeChain` parameter; it's the only call site inside the loader so this is an acceptable internal change.

## Tests

- `testFallsBackToParentLocale` — `de_AT` exists with no terms; lookup must return the `de` translation. Verified to **fail** on the unfixed code (asserted via `git stash` + re-run).
- `testRegionalLocaleOverridesParentWhenPresent` — `de_AT` and `de` both have an entry for `Sing`; the regional override wins.
- `testNonRegionalLocaleChainsToSelfOnly` — `de` alone resolves to itself (sanity: no spurious parent lookup).

All 183 existing tests still pass; phpcs and phpstan are clean.

Closes the third and last open top-3 source-grounded bug from the merged review snapshot for this plugin.
