### PR TITLE
Bump audit-stash to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"phpunit/phpunit": "^12.1",
 		"sepia/po-parser": "^6.0.1",
 		"yandex/translate-api": "dev-master",
-		"dereuromark/cakephp-audit-stash": "^0.3.0"
+		"dereuromark/cakephp-audit-stash": "^2.0.0"
 	},
 	"suggest": {
 		"dereuromark/cakephp-audit-stash": "For comprehensive audit logging of translation changes (strings and terms)",


### PR DESCRIPTION
## Summary
- bump the internal  dev dependency to v2
- keep translate's audit integration on the current internal major
