### PR TITLE
Fix plural translation collapse in DbMessagesLoader

### DIFF
--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -180,12 +180,8 @@ class DbMessagesLoader {
 
 		$pluralForms = 0;
 		$item = $results->first();
-		// There are max 6 plural forms possible but most people won't need
-		// that so will only have the required number of plural_{n} fields in db.
-		// Detect the number of forms from the selected columns, not from the
-		// values: a singular-only first row has NULL plural_{n} values, so
-		// isset() would report 0 forms and collapse every plural to its
-		// singular value.
+		// Count plural forms from the selected columns, not the values: a
+		// singular-only first row has NULL values and would report 0 forms.
 		for ($i = 7; $i >= 2; $i--) {
 			if (array_key_exists('plural_' . $i, $item)) {
 				$pluralForms = $i - 1;

--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -181,9 +181,13 @@ class DbMessagesLoader {
 		$pluralForms = 0;
 		$item = $results->first();
 		// There are max 6 plural forms possible but most people won't need
-		// that so will only have the required number of value_{n} fields in db.
+		// that so will only have the required number of plural_{n} fields in db.
+		// Detect the number of forms from the selected columns, not from the
+		// values: a singular-only first row has NULL plural_{n} values, so
+		// isset() would report 0 forms and collapse every plural to its
+		// singular value.
 		for ($i = 7; $i >= 2; $i--) {
-			if (isset($item['plural_' . $i])) {
+			if (array_key_exists('plural_' . $i, $item)) {
 				$pluralForms = $i - 1;
 
 				break;

--- a/tests/TestCase/I18n/DbMessagesLoaderTest.php
+++ b/tests/TestCase/I18n/DbMessagesLoaderTest.php
@@ -245,6 +245,54 @@ class DbMessagesLoaderTest extends TestCase {
 	}
 
 	/**
+	 * Regression: the plural-form count must not be derived from the values of
+	 * the first result row. When a singular-only term is returned before a
+	 * plural term, its NULL plural_{n} columns made the old isset() detection
+	 * report zero forms, collapsing every plural to its singular value.
+	 *
+	 * @return void
+	 */
+	public function testPluralWithSingularOnlyTermFirst(): void {
+		/** @var \Translate\Model\Table\TranslateStringsTable $TranslateStrings */
+		$TranslateStrings = $this->fetchTable('Translate.TranslateStrings');
+
+		// `de` (project 1) is already created by _setUpData().
+		$de = $TranslateStrings->TranslateTerms->TranslateLocales->find()
+			->where(['locale' => 'de', 'translate_project_id' => 1])
+			->firstOrFail();
+
+		$domainEntity = $TranslateStrings->TranslateDomains->newEntity([
+			'translate_project_id' => 1,
+			'name' => 'pluraldom',
+			'active' => true,
+		]);
+		$domain = $TranslateStrings->TranslateDomains->save($domainEntity, ['strict' => true]);
+
+		// Singular-only term first (lower id, returned before the plural term).
+		$singularOnly = ['name' => 'JustSingular', 'content' => 'NurSingular'];
+		$string = $TranslateStrings->import($singularOnly, $domain->id);
+		$TranslateStrings->TranslateTerms->import($singularOnly, $string->id, $de->id);
+
+		// Plural term afterwards.
+		$plural = [
+			'name' => 'Sing',
+			'plural' => 'Plur',
+			'content' => 'SingTrans',
+			'plural_2' => 'PlurTrans',
+		];
+		$string = $TranslateStrings->import($plural, $domain->id);
+		$TranslateStrings->TranslateTerms->import($plural, $string->id, $de->id);
+
+		$messages = (new DbMessagesLoader('pluraldom', 'de'))()->getMessages();
+
+		$this->assertSame(
+			['SingTrans', 'PlurTrans'],
+			$messages['Plur']['_context'][''],
+			'Plural must keep its plural form even when a singular-only term is loaded first.',
+		);
+	}
+
+	/**
 	 * @return void
 	 */
 	protected function _setUpData() {


### PR DESCRIPTION
Same root cause as the fix in ADmad/cakephp-i18n (cakephp/cakephp#19503): `DbMessagesLoader::_messages()` detected the number of plural forms from the **values** of the first result row using `isset()`.

When that first row is a singular-only term, its `plural_{n}` columns are `NULL`, so `isset()` reports zero plural forms. Every plural message then collapses to its singular `content`, silently dropping `plural_2`.

Real domains have far more singular-only strings than plural ones, so a singular-only row is almost always returned first - meaning plurals break nearly every time, not just intermittently. The existing tests missed it because `_setUpData()` seeds only plural terms, so the first row always has `plural_2` set.

### Change

- Detect plural forms from the selected **columns** via `array_key_exists()` instead of the values - null-safe and order-independent.
- Add a regression test: a singular-only term loaded before a plural term in the same domain. It fails on `master` (plural drops `PlurTrans`) and passes with the fix.
