### PR TITLE
Lower PHP requirement to 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4']
         db-type: [sqlite, mysql]
         prefer-lowest: ['']
         include:
-          - php-version: '8.3'
+          - php-version: '8.2'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.4']
         db-type: [sqlite, mysql]
         prefer-lowest: ['']
         include:
@@ -68,7 +68,7 @@ jobs:
         run: |
           if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
           if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
-          if [[ ${{ matrix.php-version }} == '8.3' ]]; then
+          if [[ ${{ matrix.php-version }} == '8.4' ]]; then
             vendor/bin/phpunit --coverage-clover=coverage.xml
           else
             vendor/bin/phpunit
@@ -78,7 +78,7 @@ jobs:
         run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
       - name: Code Coverage Report
-        if: success() && matrix.php-version == '8.3'
+        if: success() && matrix.php-version == '8.4'
         uses: codecov/codecov-action@v3
 
   validation:
@@ -91,7 +91,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl
           coverage: none
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://img.shields.io/codecov/c/github/dereuromark/cakephp-translate/master.svg)](https://codecov.io/github/dereuromark/cakephp-translate/branch/master)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)
 [![Latest Stable Version](https://poser.pugx.org/dereuromark/cakephp-translate/v/stable.svg)](https://packagist.org/packages/dereuromark/cakephp-translate)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.3-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/dereuromark/cakephp-translate/license.svg)](https://packagist.org/packages/dereuromark/cakephp-translate)
 [![Total Downloads](https://poser.pugx.org/dereuromark/cakephp-translate/d/total.svg)](https://packagist.org/packages/dereuromark/cakephp-translate)
 [![Coding Standards](https://img.shields.io/badge/cs-PSR--2--R-yellow.svg)](https://github.com/php-fig-rectified/fig-rectified-standards)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"source": "https://github.com/dereuromark/cakephp-translate"
 	},
 	"require": {
-		"php": ">=8.3",
+		"php": ">=8.2",
 		"cakephp/cakephp": "^5.1.6",
 		"friendsofcake/search": "^7.0"
 	},
@@ -38,7 +38,7 @@
 		"dereuromark/cakephp-data": "@stable",
 		"dereuromark/cakephp-shim": "^3.8.2",
 		"fig-r/psr2r-sniffer": "dev-master",
-		"phpunit/phpunit": "^12.1",
+		"phpunit/phpunit": "^11.5 || ^12.0 || ^13.0",
 		"sepia/po-parser": "^6.0.1",
 		"yandex/translate-api": "dev-master",
 		"dereuromark/cakephp-audit-stash": "^2.0.0"


### PR DESCRIPTION
## Problem

Users on CakePHP 5.x + PHP 8.2 cannot install the plugin:

```
Cannot use dereuromark/cakephp-translate's latest version 0.4.5 as it requires php >=8.3 which is not satisfied by your platform.
```

PHP 8.2 is still a supported runtime for CakePHP 5.x, so the plugin should install there.

## Cause

The `>=8.3` floor was introduced in commit 28bd7fb ("Cleanup.", 2025-04-25) in the same change that bumped `phpunit/phpunit` from `^10.5` to `^12.1`. PHPUnit 12 requires PHP 8.3, so the floor was raised to satisfy the **dev tooling**, not any runtime need.

Verification that 8.3 is not required at runtime:

- No PHP 8.3-only language features in `src/` (no typed class constants, `#[Override]`, `json_validate()`, dynamic class-constant fetch).
- Runtime deps only need 8.1: `cakephp/cakephp ^5.x` and `friendsofcake/search ^7.0` both floor at PHP 8.1.

## Change

- `composer.json`: `php` requirement `>=8.3` to `>=8.2`.
- `composer.json`: widen `phpunit/phpunit` to `^11.5 || ^12.0 || ^13.0` so Composer resolves the right major per PHP version (8.2 to 11.5, 8.3 to 12, 8.4 to 13).
- CI: add PHP 8.2 to the test matrix and run the `prefer-lowest` job against the actual 8.2 floor.
- README: update the minimum-PHP badge to 8.2.

Closes #61
